### PR TITLE
GHA: Add release GitHub action

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -1,0 +1,60 @@
+name: Publish dask-geopandas to PyPI / GitHub
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-n-publish:
+    name: Build and publish dask-geopandas to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+          python setup.py sdist bdist_wheel
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Get Asset name
+        run: |
+          export PKG=$(ls dist/ | grep tar)
+          set -- $PKG
+          echo "name=$1" >> $GITHUB_ENV
+
+      - name: Upload Release Asset (sdist) to GitHub
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ env.name }}
+          asset_name: ${{ env.name }}
+          asset_content_type: application/zip


### PR DESCRIPTION
Adding GitHub action to manage release. Copied from geopandas repo.

It is triggered on a tag starting `v` (as `v0.1.0`) pushed to repo and will:
1. upload a release to PyPI
2. create GitHub release

Someone needs to add a `PYPI_API_TOKEN` to repository secrets. Since there's no release on PyPI it can be anyone. Can do it myself and then give @jorisvandenbossche and @jsignell PyPI access or one of you can do it instead (so I don't claim the ownership).