### PR TITLE
REF: resolve numpy FutureWarning

### DIFF
--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -9,7 +9,6 @@ from dask.dataframe.utils import (
 from dask.dataframe.extensions import make_array_nonempty, make_scalar
 from dask.base import normalize_token
 
-import numpy as np
 import shapely.geometry
 from shapely.geometry.base import BaseGeometry
 import geopandas
@@ -28,11 +27,9 @@ def make_meta_shapely_geometry(x, index=None):
 
 @make_array_nonempty.register(GeometryDtype)
 def _(dtype):
-    a = np.array(
-        [shapely.geometry.LineString([(i, i), (i, i + 1)]) for i in range(2)],
-        dtype=object,
+    return from_shapely(
+        [shapely.geometry.LineString([(i, i), (i, i + 1)]) for i in range(2)]
     )
-    return from_shapely(a)
 
 
 @make_scalar.register(GeometryDtype.type)


### PR DESCRIPTION
We now get numpy FutureWarning due to LineString within array.

```
FutureWarning: The input object of type 'LineString' is an array-like implementing one of the corresponding protocols (`__array__`, `__array_interface__` or `__array_struct__`); but not a sequence (or 0-D). In the future, this object will be coerced as if it was first converted using `np.array(obj)`. To retain the old behaviour, you have to either modify the type 'LineString', or assign to an empty array created with `np.empty(correct_shape, dtype=object)`.
```

Since `from_shapely` does not need an array and can work with a list, I am passing it directly. Broken tests are unrelated (were already broken).