### PR TITLE
BUG: fix explode moved from GeoPandasBase in geopandas

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -282,7 +282,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
             enforce_metadata=False,
         )
 
-    @derived_from(geopandas.base.GeoPandasBase)
+    @derived_from(geopandas.geodataframe.GeoDataFrame)
     def explode(self):
         return self.map_partitions(self._partition_type.explode, enforce_metadata=False)
 


### PR DESCRIPTION
Explode implementation was moved from GeoPandasBase in https://github.com/geopandas/geopandas/pull/1720. This should fix the implementation here.