### PR TITLE
Check for `crs` before allowing `set_crs`

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -14,8 +14,7 @@ from shapely.geometry import box
 
 def _set_crs(df, crs, allow_override):
     """Return a new object with crs set to ``crs``"""
-    df = df.copy(deep=False).set_crs(crs, allow_override=allow_override)
-    return df
+    return df.set_crs(crs, allow_override=allow_override)
 
 
 def _finalize(results):

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -12,10 +12,9 @@ from shapely.geometry.base import BaseGeometry
 from shapely.geometry import box
 
 
-def _set_crs(df, crs):
+def _set_crs(df, crs, allow_override):
     """Return a new object with crs set to ``crs``"""
-    df = df.copy(deep=False)
-    df.crs = crs
+    df = df.copy(deep=False).set_crs(crs, allow_override=allow_override)
     return df
 
 
@@ -147,14 +146,15 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
     @crs.setter
     def crs(self, value):
         """Sets the value of the crs"""
-        new = self.set_crs(value)
+        # When using setter, Geopandas always overrides the CRS
+        new = self.set_crs(value, allow_override=True)
         self._meta = new._meta
         self._name = new._name
         self.dask = new.dask
 
-    def set_crs(self, value):
+    def set_crs(self, value, allow_override=False):
         """Set the value of the crs on a new object"""
-        return self.map_partitions(_set_crs, value, enforce_metadata=False)
+        return self.map_partitions(_set_crs, value, allow_override, enforce_metadata=False)
 
     def to_crs(self, crs=None, epsg=None):
         token = f"{self._name}-to_crs"

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -153,7 +153,9 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
     def set_crs(self, value, allow_override=False):
         """Set the value of the crs on a new object"""
-        return self.map_partitions(_set_crs, value, allow_override, enforce_metadata=False)
+        return self.map_partitions(
+            _set_crs, value, allow_override, enforce_metadata=False
+        )
 
     def to_crs(self, crs=None, epsg=None):
         token = f"{self._name}-to_crs"

--- a/notebooks/basic-intro.ipynb
+++ b/notebooks/basic-intro.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "import geopandas\n",
     "\n",
     "import dask.dataframe as dd\n",
@@ -385,15 +386,6 @@
    "metadata": {},
    "source": [
     "The GeoDataFrame used above is a bit small to see any benefit from parallelization using dask (as the overhead of the task scheduler is larger than the actual operation on such a tiny dataframe), so let's create a bigger point GeoSeries:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np"
    ]
   },
   {

--- a/notebooks/basic-intro.ipynb
+++ b/notebooks/basic-intro.ipynb
@@ -389,6 +389,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [],
@@ -551,9 +560,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (geo-dev)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "geo-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -565,7 +574,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,7 +144,7 @@ def test_geodataframe_crs(geodf_points_crs):
     assert dask_obj.partitions[1].crs == original
 
     new_crs = "epsg:4316"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r'.*already has a CRS which is not equal to the passed CRS.*'):
         dask_obj.set_crs(new_crs)
 
     new = dask_obj.set_crs(new_crs, allow_override=True)
@@ -169,8 +169,8 @@ def test_geoseries_crs(geoseries_points_crs):
     assert dask_obj.compute().crs == original
 
     new_crs = "epsg:4316"
-    with pytest.raises(ValueError):
-        dask_obj.set_crs(new_crs)
+    with pytest.raises(ValueError, match=r'.*already has a CRS which is not equal to the passed CRS.*'):
+            dask_obj.set_crs(new_crs)
 
     new = dask_obj.set_crs(new_crs, allow_override=True)
     assert new.crs == new_crs

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -166,7 +166,10 @@ def test_geoseries_crs(geoseries_points_crs):
     assert dask_obj.compute().crs == original
 
     new_crs = "epsg:4316"
-    new = dask_obj.set_crs("epsg:4316")
+    with pytest.raises(ValueError):
+        dask_obj.set_crs(new_crs)
+
+    new = dask_obj.set_crs(new_crs, allow_override=True)
     assert new.crs == new_crs
     assert new.name == name
     assert new.partitions[1].crs == new_crs

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,7 +144,10 @@ def test_geodataframe_crs(geodf_points_crs):
     assert dask_obj.partitions[1].crs == original
 
     new_crs = "epsg:4316"
-    new = dask_obj.set_crs("epsg:4316")
+    with pytest.raises(ValueError):
+        dask_obj.set_crs(new_crs)
+
+    new = dask_obj.set_crs(new_crs, allow_override=True)
     assert new.crs == new_crs
     assert new.partitions[1].crs == new_crs
     assert dask_obj.crs == original

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -144,7 +144,9 @@ def test_geodataframe_crs(geodf_points_crs):
     assert dask_obj.partitions[1].crs == original
 
     new_crs = "epsg:4316"
-    with pytest.raises(ValueError, match=r'.*already has a CRS which is not equal to the passed CRS.*'):
+    with pytest.raises(
+        ValueError, match=r".*already has a CRS which is not equal to the passed CRS.*"
+    ):
         dask_obj.set_crs(new_crs)
 
     new = dask_obj.set_crs(new_crs, allow_override=True)
@@ -169,8 +171,10 @@ def test_geoseries_crs(geoseries_points_crs):
     assert dask_obj.compute().crs == original
 
     new_crs = "epsg:4316"
-    with pytest.raises(ValueError, match=r'.*already has a CRS which is not equal to the passed CRS.*'):
-            dask_obj.set_crs(new_crs)
+    with pytest.raises(
+        ValueError, match=r".*already has a CRS which is not equal to the passed CRS.*"
+    ):
+        dask_obj.set_crs(new_crs)
 
     new = dask_obj.set_crs(new_crs, allow_override=True)
     assert new.crs == new_crs


### PR DESCRIPTION
The behaviour should follow GeoPandas' behaviour, that is
- Raises ValueError if setting a different crs with `allow_override=False`
- Overwrites the crs if `allow_override=True`
- Overwrites the crs when using `crs.setter`

closes #3 