### PR TITLE
CI: test against different dask versions + update minimum dask version

### DIFF
--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7
-  - dask=2.2
+  - dask=2.18
   - distributed
   - geopandas
   - pygeos

--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7
-  - dask
+  - dask=2.2
   - distributed
   - geopandas
   - pygeos

--- a/continuous_integration/envs/38-latest.yaml
+++ b/continuous_integration/envs/38-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
-  - dask
+  - dask=2021.05
   - distributed
   - geopandas
   - pygeos

--- a/continuous_integration/envs/38-latest.yaml
+++ b/continuous_integration/envs/38-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
-  - dask=2021.05
+  - dask=2021.05.0
   - distributed
   - geopandas
   - pygeos

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 import versioneer
 
-install_requires = ["geopandas", "dask>=2.2.0", "distributed>=2.2.0"]
+install_requires = ["geopandas", "dask>=2.18.0", "distributed>=2.18.0"]
 
 
 setup(


### PR DESCRIPTION
@martinfleis @jsignell I don't know to what extent we want to test against different dask version (except latest release + master) in the current alpha phase of the project, but https://github.com/geopandas/dask-geopandas/pull/50 is adding some custom code for versions older than 2021.06, which would be not covered in the current CI setup