### PR TITLE
BUG: set_crs takes spatial_partitions into account

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -153,9 +153,14 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
     def set_crs(self, value, allow_override=False):
         """Set the value of the crs on a new object"""
-        return self.map_partitions(
+        new = self.map_partitions(
             _set_crs, value, allow_override, enforce_metadata=False
         )
+        if self.spatial_partitions is not None:
+            new.spatial_partitions = self.spatial_partitions.set_crs(
+                value, allow_override=allow_override
+            )
+        return new
 
     def to_crs(self, crs=None, epsg=None):
         token = f"{self._name}-to_crs"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import dask.dataframe as dd
 from dask.dataframe.core import Scalar
 import dask_geopandas
 
-from geopandas.testing import assert_geodataframe_equal
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 
 @pytest.fixture
@@ -361,6 +361,25 @@ def test_copy_spatial_partitions(geodf_points):
     pd.testing.assert_series_equal(
         dask_obj.spatial_partitions, dask_obj_copy.spatial_partitions
     )
+
+
+def test_set_crs_sets_spatial_partition_crs(geodf_points):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+
+    dask_obj.calculate_spatial_partitions()
+    dask_obj = dask_obj.set_crs("epsg:4326")
+
+    assert dask_obj.crs == dask_obj.spatial_partitions.crs
+
+
+def test_propagate_on_set_crs(geodf_points):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+
+    dask_obj.calculate_spatial_partitions()
+    result = dask_obj.set_crs("epsg:4326").spatial_partitions
+    expected = dask_obj.spatial_partitions.set_crs("epsg:4326")
+
+    assert_geoseries_equal(result, expected)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
- sets the crs on spatial_partitions
- propagates them to the resulting dataframe

closes #58 