### PR TITLE
ENH: Implement geopandas.clip

### DIFF
--- a/dask_geopandas/__init__.py
+++ b/dask_geopandas/__init__.py
@@ -1,6 +1,7 @@
 from ._version import get_versions
 
 from . import backends
+from .clip import clip
 from .core import (
     points_from_xy,
     GeoDataFrame,
@@ -22,4 +23,5 @@ __all__ = [
     "from_dask_dataframe",
     "read_parquet",
     "to_parquet",
+    "clip",
 ]

--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -3,15 +3,15 @@ import geopandas
 
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import derived_from
-from dask.base import tokenize, DaskMethodsMixin
+from dask.base import tokenize
 
-from .core import GeoDataFrame
+from .core import GeoDataFrame, GeoSeries
 
 
 @derived_from(geopandas.tools)
 def clip(gdf, mask, keep_geom_type=False):
-    if isinstance(mask, DaskMethodsMixin):
-        raise NotImplementedError("Mask cannot be a Dask object.")
+    if isinstance(mask, GeoDataFrame) or isinstance(mask, GeoSeries):
+        raise NotImplementedError("Mask cannot be a Dask GeoDataFrame or GeoSeries.")
 
     if gdf.spatial_partitions is None:
         return gdf.map_partitions(

--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -10,7 +10,7 @@ from .core import GeoDataFrame, GeoSeries
 
 @derived_from(geopandas.tools)
 def clip(gdf, mask, keep_geom_type=False):
-    if isinstance(mask, GeoDataFrame) or isinstance(mask, GeoSeries):
+    if isinstance(mask, (GeoDataFrame, GeoSeries)):
         raise NotImplementedError("Mask cannot be a Dask GeoDataFrame or GeoSeries.")
 
     if gdf.spatial_partitions is None:

--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -1,0 +1,38 @@
+import numpy as np
+import geopandas
+
+from dask.highlevelgraph import HighLevelGraph
+from dask.utils import derived_from
+from dask.base import tokenize
+
+from .core import GeoDataFrame
+
+
+@derived_from(geopandas.tools)
+def clip(gdf, mask, keep_geom_type=False):
+    if gdf.spatial_partitions is None:
+        return gdf.map_partitions(
+            lambda partition: geopandas.clip(
+                gdf=partition, mask=mask, keep_geom_type=keep_geom_type
+            ),
+            token="clip",
+            meta=gdf._meta,
+        )
+
+    new_spatial_partitions = geopandas.clip(
+        gdf=gdf.spatial_partitions.to_frame("geometry"),
+        mask=mask,
+    )
+    intersecting_partitions = np.asarray(new_spatial_partitions.index)
+
+    name = f"clip-{tokenize(gdf, mask, keep_geom_type)}"
+    dsk = {
+        (name, i): (geopandas.clip, (gdf._name, l), mask, keep_geom_type)
+        for i, l in enumerate(intersecting_partitions)
+    }
+    divisions = [None] * (len(dsk) + 1)
+    graph = HighLevelGraph.from_collections(name, dsk, dependencies=[gdf])
+    result = GeoDataFrame(graph, name, gdf._meta, tuple(divisions))
+    result.spatial_partitions = new_spatial_partitions
+
+    return result

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -27,5 +27,7 @@ def test_clip_no_spatial_partitions(geodf_points):  # noqa: F811
 def test_clip_dask_mask(geodf_points):  # noqa: F811
     dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
     mask = dask_geopandas.from_geopandas(geodf_points.iloc[:1], npartitions=1)
-    with pytest.raises(NotImplementedError, match=r"Mask cannot be a Dask object"):
+    with pytest.raises(
+        NotImplementedError, match=r"Mask cannot be a Dask GeoDataFrame or GeoSeries."
+    ):
         dask_geopandas.clip(dask_obj, mask)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,10 +1,10 @@
 import geopandas
 from geopandas.testing import assert_geodataframe_equal
 import dask_geopandas
-from .test_core import geodf_points
+from .test_core import geodf_points  # noqa: F401
 
 
-def test_clip(geodf_points):
+def test_clip(geodf_points):  # noqa: F811
     dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
     dask_obj.calculate_spatial_partitions()
     mask = geodf_points.iloc[:1]
@@ -14,7 +14,7 @@ def test_clip(geodf_points):
     assert_geodataframe_equal(expected, result)
 
 
-def test_clip_no_spatial_partitions(geodf_points):
+def test_clip_no_spatial_partitions(geodf_points):  # noqa: F811
     dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
     mask = geodf_points.iloc[:1]
     mask["geometry"] = mask["geometry"].buffer(2)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,0 +1,23 @@
+import geopandas
+from geopandas.testing import assert_geodataframe_equal
+import dask_geopandas
+from .test_core import geodf_points
+
+
+def test_clip(geodf_points):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    dask_obj.calculate_spatial_partitions()
+    mask = geodf_points.iloc[:1]
+    mask["geometry"] = mask["geometry"].buffer(2)
+    expected = dask_obj.map_partitions(lambda gdf: geopandas.clip(gdf, mask)).compute()
+    result = dask_geopandas.clip(dask_obj, mask).compute()
+    assert_geodataframe_equal(expected, result)
+
+
+def test_clip_no_spatial_partitions(geodf_points):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    mask = geodf_points.iloc[:1]
+    mask["geometry"] = mask["geometry"].buffer(2)
+    expected = geodf_points.iloc[:2]
+    result = dask_geopandas.clip(dask_obj, mask).compute()
+    assert_geodataframe_equal(expected, result)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,5 +1,6 @@
 import geopandas
 from geopandas.testing import assert_geodataframe_equal
+import pytest
 import dask_geopandas
 from .test_core import geodf_points  # noqa: F401
 
@@ -9,7 +10,7 @@ def test_clip(geodf_points):  # noqa: F811
     dask_obj.calculate_spatial_partitions()
     mask = geodf_points.iloc[:1]
     mask["geometry"] = mask["geometry"].buffer(2)
-    expected = dask_obj.map_partitions(lambda gdf: geopandas.clip(gdf, mask)).compute()
+    expected = geopandas.clip(geodf_points, mask)
     result = dask_geopandas.clip(dask_obj, mask).compute()
     assert_geodataframe_equal(expected, result)
 
@@ -21,3 +22,10 @@ def test_clip_no_spatial_partitions(geodf_points):  # noqa: F811
     expected = geodf_points.iloc[:2]
     result = dask_geopandas.clip(dask_obj, mask).compute()
     assert_geodataframe_equal(expected, result)
+
+
+def test_clip_dask_mask(geodf_points):  # noqa: F811
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    mask = dask_geopandas.from_geopandas(geodf_points.iloc[:1], npartitions=1)
+    with pytest.raises(NotImplementedError, match=r"Mask cannot be a Dask object"):
+        dask_geopandas.clip(dask_obj, mask)


### PR DESCRIPTION
A couple of notes/questions
- Is the token correct like this? (not using `gdf._name`, starting with `clip`)
- I have imported a pytest fixture from `test_core` and had to ignore flake warnings because of it. Not sure this is best way to go about it.

Commit message:
```
If no spatial partitions are available, just map_partitions
If spatial partitions are available, construct the graph
only for spatial partitions intersecting the mask.

keep_geom_type is always false for clipping the 
spatial partitions: otherwise we'd be falsely creating
new partition(s)
```

closes #57 