### PR TITLE
Don't prepend task token with parent object name

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -162,8 +162,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
         return new
 
     def to_crs(self, crs=None, epsg=None):
-        token = "to_crs"
-        return self.map_partitions(M.to_crs, crs=crs, epsg=epsg, token=token)
+        return self.map_partitions(M.to_crs, crs=crs, epsg=epsg)
 
     def copy(self):
         """Make a copy of the dataframe
@@ -332,7 +331,7 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         self.dask = new.dask
 
     def set_geometry(self, col):
-        return self.map_partitions(M.set_geometry, col, token="set_geometry")
+        return self.map_partitions(M.set_geometry, col)
 
     def __getitem__(self, key):
         """

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -74,8 +74,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
         def prop(self):
             meta = getattr(self._meta, attr)
-            token = f"{self._name}-{attr}"
-            result = self.map_partitions(getattr, attr, token=token, meta=meta)
+            result = self.map_partitions(getattr, attr, token=attr, meta=meta)
             if preserve_spatial_partitions:
                 result = self._propagate_spatial_partitions(result)
             return result
@@ -163,7 +162,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
         return new
 
     def to_crs(self, crs=None, epsg=None):
-        token = f"{self._name}-to_crs"
+        token = "to_crs"
         return self.map_partitions(M.to_crs, crs=crs, epsg=epsg, token=token)
 
     def copy(self):
@@ -191,7 +190,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
         return self.reduction(
             lambda x: getattr(x, "total_bounds"),
-            token=self._name + "-total_bounds",
+            token="total_bounds",
             meta=self._meta.total_bounds,
             aggregate=agg,
         )
@@ -209,7 +208,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
         return self.reduction(
             lambda x: getattr(x, attr),
-            token=f"{self._name}-{attr}",
+            token=attr,
             aggregate=lambda x: getattr(geopandas.GeoSeries(x), attr),
             meta=meta,
         )
@@ -333,8 +332,7 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         self.dask = new.dask
 
     def set_geometry(self, col):
-        token = f"{self._name}-set_geometry"
-        return self.map_partitions(M.set_geometry, col, token=token)
+        return self.map_partitions(M.set_geometry, col, token="set_geometry")
 
     def __getitem__(self, key):
         """
@@ -378,7 +376,9 @@ def points_from_xy(df, x="x", y="y", z="z"):
             index=data.index,
         )
 
-    return df.map_partitions(func, x, y, z, meta=geopandas.GeoSeries())
+    return df.map_partitions(
+        func, x, y, z, meta=geopandas.GeoSeries(), token="points_from_xy"
+    )
 
 
 for name in [


### PR DESCRIPTION
While inspecting the task graphs, I noticed that some methods from dask_geopandas were not showing up properly. The reason is that we had for example a task graph key such as " from_pandas-539469e91d2728523cacb4ce24809e38-total_bounds-agg-5c149902dcdf5b43358d736407dca688" (from `token=self._name + "-total_bounds"`, where in this case the parent was created from a pandas dataframe) which gets abbreviated to "from_pandas" in the visualization and html repr. With this change, it would get abbreviated as "total_bounds-agg".

I looked in dask.dataframe itself, and they don't seem to prepend the token with `self._name`. For some methods they do prepend with `series-` or `dataframe-` (this is defined as `self._token_prefix`). We could also do something similar and add a "geo-" prefix. Although I think most of our methods have a quite descriptive name.

cc @jsignell 