### PR TITLE
DEV/CI: update black and flake8 versions (pre-commit autoupdate)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.6b0
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.9.2
     hooks:
       - id: flake8
         language_version: python3


### PR DESCRIPTION
Pre-commit was complaining with

```
[WARNING] The 'rev' field of repo 'https://github.com/psf/black' appears to be a mutable
reference (moving tag / branch).  Mutable references are never updated after first install
and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository
for more details.  Hint: `pre-commit autoupdate` often fixes this.
```