### PR TITLE
DOC: Fix docstring meta for _Frame in core.py

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -37,7 +37,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
         The key prefix that specifies which keys in the dask comprise this
         particular DataFrame / Series
     meta : geopandas.GeoDataFrame, geopandas.GeoSeries
-        An empty cudf object with names, dtypes, and indices matching the
+        An empty geopandas object with names, dtypes, and indices matching the
         expected output.
     divisions : tuple of index values
         Values along which we partition our blocks on the index


### PR DESCRIPTION
The meta in `_Frame`  expects a geopandas object, not a cudf object.