### PR TITLE
BUG: read CRS in read_parquet

### DIFF
--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -58,11 +58,6 @@ class GeoArrowEngine(ArrowEngine):
     def read_metadata(cls, *args, **kwargs):
         meta, stats, parts, index = super().read_metadata(*args, **kwargs)
 
-        # Update meta to be a GeoDataFrame
-        # TODO convert columns based on GEO metadata (this will now only work
-        # for a default "geometry" column)
-        meta = geopandas.GeoDataFrame(meta)
-
         # get spatial partitions if available
         regions = geopandas.GeoSeries([_get_partition_bounds(part) for part in parts])
         if regions.notna().all():
@@ -70,6 +65,21 @@ class GeoArrowEngine(ArrowEngine):
             meta.attrs["spatial_partitions"] = regions
 
         return (meta, stats, parts, index)
+
+    @classmethod
+    def _generate_dd_meta(cls, schema, index, categories, partition_info):
+        meta, index_cols, categories, index, partition_info = super()._generate_dd_meta(schema, index, categories, partition_info)
+        if b"geo" in schema.metadata:
+            geo_meta = json.loads(schema.metadata[b"geo"])
+            crs = geo_meta["columns"][geo_meta["primary_column"]]["crs"]
+        else:
+            crs = None
+
+        # Update meta to be a GeoDataFrame
+        # TODO convert columns based on GEO metadata (this will now only work
+        # for a default "geometry" column)
+        meta = geopandas.GeoDataFrame(meta, crs=crs)
+        return meta, index_cols, categories, index, partition_info
 
     @classmethod
     def _arrow_table_to_pandas(

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -68,7 +68,9 @@ class GeoArrowEngine(ArrowEngine):
 
     @classmethod
     def _generate_dd_meta(cls, schema, index, categories, partition_info):
-        meta, index_cols, categories, index, partition_info = super()._generate_dd_meta(schema, index, categories, partition_info)
+        meta, index_cols, categories, index, partition_info = super()._generate_dd_meta(
+            schema, index, categories, partition_info
+        )
         if b"geo" in schema.metadata:
             geo_meta = json.loads(schema.metadata[b"geo"])
             crs = geo_meta["columns"][geo_meta["primary_column"]]["crs"]

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -71,7 +71,7 @@ class GeoArrowEngine(ArrowEngine):
         meta, index_cols, categories, index, partition_info = super()._generate_dd_meta(
             schema, index, categories, partition_info
         )
-        if b"geo" in schema.metadata:
+        if schema.metadata and b"geo" in schema.metadata:
             geo_meta = json.loads(schema.metadata[b"geo"])
             crs = geo_meta["columns"][geo_meta["primary_column"]]["crs"]
         else:

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -30,6 +30,8 @@ def test_parquet_roundtrip(tmp_path):
     result = dask_geopandas.read_parquet(basedir)
     assert result.npartitions == 4
     assert_geodataframe_equal(result.compute(), df)
+    # reading back correctly sets the CRS in meta
+    assert result.crs == df.crs
     # reading back also populates the spatial partitioning property
     assert result.spatial_partitions is not None
 
@@ -42,7 +44,6 @@ def test_parquet_roundtrip(tmp_path):
     result_part0 = geopandas.read_parquet(basedir / "part.0.parquet")
     result_part0.index.name = None
     assert_geodataframe_equal(result_part0, df.iloc[:45])
-    assert result.crs == df.crs
 
 
 def test_column_selection_push_down(tmp_path):

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -42,6 +42,7 @@ def test_parquet_roundtrip(tmp_path):
     result_part0 = geopandas.read_parquet(basedir / "part.0.parquet")
     result_part0.index.name = None
     assert_geodataframe_equal(result_part0, df.iloc[:45])
+    assert result.crs == df.crs
 
 
 def test_column_selection_push_down(tmp_path):


### PR DESCRIPTION
This sets the CRS when reading back a file that was written with the `geo-arrow-spec`'s metadata.

It's moves the conversion of the Dask `meta` dataframe down to a private method unfortunately, but AFAICT, that's the most convenient place to get access to the Parquet Dataset, so that we can read the `.schema.metadata`. I didn't look too closely.

Closes https://github.com/geopandas/dask-geopandas/issues/96