### PR TITLE
ENH: improve text repr of GeoSeries/GeoDataFrame

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -67,10 +67,6 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
     def __dask_postpersist__(self):
         return type(self), (self._name, self._meta, self.divisions)
 
-    def __repr__(self):
-        s = "<dask_geopandas.%s | %d tasks | %d npartitions>"
-        return s % (type(self).__name__, len(self.dask), self.npartitions)
-
     @classmethod
     def _bind_property(cls, attr, preserve_spatial_partitions=False):
         """Map property to partitions and bind to class"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -394,6 +394,8 @@ def test_geoseries_apply(geoseries_polygons):
     pd.testing.assert_series_equal(result, expected)
 
 
-def test_geodataframe_html_repr(geodf_points):
+def test_repr(geodf_points):
     dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    assert "Dask GeoDataFrame" in dask_obj.__repr__()
+    assert "Dask GeoSeries" in dask_obj.geometry.__repr__()
     assert "Dask-GeoPandas GeoDataFrame" in dask_obj._repr_html_()


### PR DESCRIPTION
If we rely on the dask implementation instead of overriding it, we actually already get a repr with the correct class name included:

```python
In [1]: import dask_geopandas

In [2]: df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))

In [3]: ddf = dask_geopandas.from_geopandas(df, npartitions=4)

In [4]: ddf
Out[4]: 
Dask GeoDataFrame Structure:
              pop_est continent    name  iso_a3 gdp_md_est  geometry
npartitions=4                                                       
0               int64    object  object  object    float64  geometry
45                ...       ...     ...     ...        ...       ...
90                ...       ...     ...     ...        ...       ...
135               ...       ...     ...     ...        ...       ...
176               ...       ...     ...     ...        ...       ...
Dask Name: from_pandas, 4 tasks

In [5]: ddf.geometry
Out[5]: 
Dask GeoSeries Structure:
npartitions=4
0      geometry
45          ...
90          ...
135         ...
176         ...
Name: geometry, dtype: geometry
Dask Name: getitem, 8 tasks
```

which is much more informative as the current one we define ourselves:

```python
In [2]: ddf
Out[2]: <dask_geopandas.GeoDataFrame | 4 tasks | 4 npartitions>
```

I could still do a `super().__repr__().replace("Dask GeoDataFrame Structure", "Dask-GeoPandas GeoDataFrame Structure")` to include "Dask-GeoPandas instead of "Dask" (as I did for the html repr), but maybe that's not really necessary.