### PR TITLE
Documentation: Update Z-order wikipedia link page reference

### DIFF
--- a/dask_geopandas/morton_distance.py
+++ b/dask_geopandas/morton_distance.py
@@ -6,7 +6,7 @@ def _morton_distance(gdf, total_bounds, p):
     """
     Calculate distance of geometries along Morton curve
 
-    The Morton curve is also known as Z-order https://en.wikipedia.org/wiki/Z-order
+    The Morton curve is also known as Z-order https://en.wikipedia.org/wiki/Z-order_curve
 
     Parameters
     ----------


### PR DESCRIPTION
Cool project. While reading through some of the source code (and learning about some of the concepts) I noticed that the wikipedia page in the documentation was for a graphics concept and not the mathematics one. Perhaps the wiki page originally routed to a disambiguation page when the doc-string was first created.