### PR TITLE
BUG: correctly set CRS of spatial_partitions in read_parquet

### DIFF
--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -59,7 +59,9 @@ class GeoArrowEngine(ArrowEngine):
         meta, stats, parts, index = super().read_metadata(*args, **kwargs)
 
         # get spatial partitions if available
-        regions = geopandas.GeoSeries([_get_partition_bounds(part) for part in parts])
+        regions = geopandas.GeoSeries(
+            [_get_partition_bounds(part) for part in parts], crs=meta.crs
+        )
         if regions.notna().all():
             # a bit hacky, but this allows us to get this passed through
             meta.attrs["spatial_partitions"] = regions

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -34,6 +34,7 @@ def test_parquet_roundtrip(tmp_path):
     assert result.crs == df.crs
     # reading back also populates the spatial partitioning property
     assert result.spatial_partitions is not None
+    assert result.spatial_partitions.crs == df.crs
 
     # the written dataset is also readable by plain geopandas
     result_gpd = geopandas.read_parquet(basedir)


### PR DESCRIPTION
Encountered this while trying the sjoin benchmarks from spatialpandas, getting warnings about mismatching CRS in sjoin.