### PR TITLE
Fix msgpack serialization error for sjoin algo

### DIFF
--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -73,7 +73,13 @@ def sjoin(left, right, how="inner", op="intersects"):
     dsk = {}
     new_spatial_partitions = []
     for i, (l, r) in enumerate(zip(parts_left, parts_right)):
-        dsk[(name, i)] = (geopandas.sjoin, (left._name, l), (right._name, r), how, op)
+        dsk[(name, i)] = (
+            geopandas.sjoin,
+            (left._name, int(l)),
+            (right._name, int(r)),
+            how,
+            op,
+        )
         # TODO preserve spatial partitions of the output if only left has spatial
         # partitions
         if using_spatial_partitions:


### PR DESCRIPTION
With a larger dataset and the distributed scheduler, I am sometimes running into the following error when doing an `sjoin`:

```
...
distributed.protocol.core - CRITICAL - Failed to Serialize
Traceback (most recent call last):
  File "/home/joris/miniconda3/envs/geo/lib/python3.9/site-packages/distributed/protocol/core.py", line 76, in dumps
    frames[0] = msgpack.dumps(msg, default=_encode_default, use_bin_type=True)
  File "/home/joris/miniconda3/envs/geo/lib/python3.9/site-packages/msgpack/__init__.py", line 35, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 292, in msgpack._cmsgpack.Packer.pack
  File "msgpack/_packer.pyx", line 298, in msgpack._cmsgpack.Packer.pack
  File "msgpack/_packer.pyx", line 295, in msgpack._cmsgpack.Packer.pack
  File "msgpack/_packer.pyx", line 264, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 231, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 231, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 264, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 231, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 231, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 231, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 264, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 264, in msgpack._cmsgpack.Packer._pack
  File "msgpack/_packer.pyx", line 289, in msgpack._cmsgpack.Packer._pack
TypeError: can not serialize 'numpy.int64' object
distributed.comm.utils - ERROR - can not serialize 'numpy.int64' object
```

Unfortunately I can't reproduce this with a smaller dataset (eg the naturalearth cities / countries), so I can't write a test for it. But it seems to only happen when 1) using the distributed scheduler (otherwise msgpack is not used to transfer the graph I suppose), 2) if both left/right geodataframe passed to the `sjoin` are dask dataframes ànd have spatial partitioning information. (cc @jsignell do you have seen such errors before with dask?) 
I find it a bit strange that it only happens then, because in all cases (both if the spatial partitioning is used and when not), the indices for the left/right partitions to combine are created as numpy arrays (and then afterwards iterated over):

https://github.com/geopandas/dask-geopandas/blob/329af51aa1d8fb5470b4df7322ed08f70c5773b1/dask_geopandas/sjoin.py#L65-L76

Anyway, what fixes it is adding a `int(..)` around the numpy integer when adding the key in the task graph. So while I can't really explain it / add a test for it, this fixes it ..