### PR TITLE
DOC: Add a note that pyarrow is required to write Parquet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,10 @@ format:
    ddf.to_parquet("path/to/dir/")
    ddf = dask_geopandas.read_parquet("path/to/dir/")
 
+.. note::
+
+   Writing to Parquet files requires installing the ``pyarrow`` library, e.g. ``pip install pyarrow``.
+
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,8 @@ format:
 
 .. note::
 
-   Writing to Parquet files requires installing the ``pyarrow`` library, e.g. ``pip install pyarrow``.
+   Writing to Parquet files requires installing the ``pyarrow`` library, e.g.
+   ``conda install pyarrow`` or ``pip install pyarrow``.
 
 
 Installation


### PR DESCRIPTION
If pyarrow is not installed, the following error occurs when writing Parquet tables (following the readme example):

```
>       meta, schema, i_offset = engine.initialize_write(
            df,
            fs,
            path,
            append=append,
            ignore_divisions=ignore_divisions,
            partition_on=partition_on,
            division_info=division_info,
            index_cols=index_cols,
            schema=schema,
            **kwargs_pass,
        )
E       AttributeError: type object 'GeoArrowEngine' has no attribute 'initialize_write'
```

This is due to `pyarrow` being an optional dependency [here](https://github.com/gadomski/dask-geopandas/blob/6ce7b8e0390aed3b6a7584ba0f6e42d65d0c98e8/dask_geopandas/io/parquet.py#L12-L16). The error message could probably be made better as well, but I wasn't quite the best way to report an error from the `to_parquet` method [here](https://github.com/gadomski/dask-geopandas/blob/master/dask_geopandas/io/parquet.py#L152) because it's made with `partial`.

## Environment

- dask==2021.11.1
- dask-geopandas==0.1.0a5
- geopandas==0.10.2