### PR TITLE
CI: remove the pyproj 2.6 pin

### DIFF
--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -9,7 +9,7 @@ dependencies:
   - distributed
   - geopandas
   - pygeos
-  - pyproj=2.6  # unpin when pyproj 3.1 is released with multithreading fix
+  - pyproj=2.6
   # test dependencies
   - pytest
   - pytest-cov

--- a/continuous_integration/envs/38-latest.yaml
+++ b/continuous_integration/envs/38-latest.yaml
@@ -9,7 +9,7 @@ dependencies:
   - distributed
   - geopandas
   - pygeos
-  - pyproj=2.6  # unpin when pyproj 3.1 is released with multithreading fix
+  - pyproj=3.1
   # test dependencies
   - pytest
   - pytest-cov

--- a/continuous_integration/envs/39-dev.yaml
+++ b/continuous_integration/envs/39-dev.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - shapely
   - fiona
-  - pyproj=2.6  # unpin when pyproj 3.1 is released with multithreading fix
+  - pyproj
   - fsspec
   # test dependencies
   - pytest

--- a/continuous_integration/envs/39-latest.yaml
+++ b/continuous_integration/envs/39-latest.yaml
@@ -9,7 +9,7 @@ dependencies:
   - distributed
   - geopandas
   - pygeos
-  - pyproj=2.6  # unpin when pyproj 3.1 is released with multithreading fix
+  - pyproj
   # test dependencies
   - pytest
   - pytest-cov


### PR DESCRIPTION
In the meantime there are pyproj 3.1+ releases that have fixed the issue in pyproj 3.0 (https://github.com/geopandas/dask-geopandas/pull/36#issuecomment-791898795), so we can remove the global 2.6 pin. I noted in https://github.com/geopandas/dask-geopandas/pull/123 however that this seems to give a windows failure related to S3 / AWS (I suppose triggered by the packages updates, by no longer pinning to an old pyproj version and thus also old versions of other packages). 