### PR TITLE
Pass through `crs` when using `points_from_xy`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ data.
 
    ddf = dask_geopandas.from_dask_dataframe(ddf)
    ddf = ddf.set_geometry(
-       dask_geopandas.points_from_xy(ddf, 'latitude', 'longitude')
+       dask_geopandas.points_from_xy(ddf, 'longitude', 'latitude')
    )
 
 Writing files (and reading back) is currently supported for the Parquet file

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -511,13 +511,13 @@ def from_dask_dataframe(df):
     return df.map_partitions(geopandas.GeoDataFrame)
 
 
-def points_from_xy(df, x="x", y="y", z="z"):
+def points_from_xy(df, x="x", y="y", z="z", crs=None):
     """Convert dask.dataframe of x and y (and optionally z) values to a GeoSeries."""
 
     def func(data, x, y, z):
         return geopandas.GeoSeries(
             geopandas.points_from_xy(
-                data[x], data[y], data[z] if z in df.columns else None
+                data[x], data[y], data[z] if z in df.columns else None, crs=crs
             ),
             index=data.index,
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black
+flake8
+hilbertcurve
+pymorton
+pytest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,6 +135,21 @@ def test_points_from_xy():
     assert_geodataframe_equal(result, expected)
 
 
+def test_points_from_xy_with_crs():
+    latitude = [40.2, 66.3]
+    longitude = [-105.1, -38.2]
+    expected = geopandas.GeoSeries(
+        geopandas.points_from_xy(longitude, latitude, crs="EPSG:4326")
+    )
+    df = pd.DataFrame({"longitude": longitude, "latitude": latitude})
+    ddf = dd.from_pandas(df, npartitions=2)
+    actual = dask_geopandas.points_from_xy(
+        ddf, "longitude", "latitude", crs="EPSG:4326"
+    )
+    assert isinstance(actual, dask_geopandas.GeoSeries)
+    assert_geoseries_equal(actual.compute(), expected)
+
+
 def test_geodataframe_crs(geodf_points_crs):
     df = geodf_points_crs
     original = df.crs


### PR DESCRIPTION
This enables the usage [in the readme](https://github.com/geopandas/dask-geopandas/blob/master/README.rst#example) to have a CRS on the resultant data frame (which is needed for writing to parquet).

Sidecar fixes:
- Swaps 'longitude' and 'latitude' in the readme as they were incorrect
- Adds a `requirements-dev.txt` file that contains the packages needed to run the test suite locally