### PR TITLE
MAINT: replace LooseVersion with packaging

### DIFF
--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -10,6 +10,7 @@ dependencies:
   - geopandas
   - pygeos
   - pyproj=2.6
+  - packaging
   # test dependencies
   - pytest
   - pytest-cov
@@ -18,4 +19,4 @@ dependencies:
   - pygeohash
   - pip
   - pip:
-    - pymorton
+      - pymorton

--- a/continuous_integration/envs/38-latest.yaml
+++ b/continuous_integration/envs/38-latest.yaml
@@ -10,6 +10,7 @@ dependencies:
   - geopandas
   - pygeos
   - pyproj=3.1
+  - packaging
   # test dependencies
   - pytest
   - pytest-cov
@@ -19,7 +20,7 @@ dependencies:
   - pygeohash
   - pip
   - pip:
-    - pymorton
-    # installing those with conda in this environments keep hanging, so installing with pip
-    - s3fs
-    - moto[s3,server]
+      - pymorton
+      # installing those with conda in this environments keep hanging, so installing with pip
+      - s3fs
+      - moto[s3,server]

--- a/continuous_integration/envs/39-dev.yaml
+++ b/continuous_integration/envs/39-dev.yaml
@@ -11,6 +11,7 @@ dependencies:
   - fiona
   - pyproj
   - fsspec
+  - packaging
   # test dependencies
   - pytest
   - pytest-cov

--- a/continuous_integration/envs/39-latest.yaml
+++ b/continuous_integration/envs/39-latest.yaml
@@ -10,16 +10,17 @@ dependencies:
   - geopandas
   - pygeos
   - pyproj
+  - packaging
   # test dependencies
   - pytest
   - pytest-cov
   - hilbertcurve
   - s3fs
   - moto
-  - flask  # needed for moto server
+  - flask # needed for moto server
   # optional dependencies
   - pyarrow
   - pygeohash
   - pip
   - pip:
-    - pymorton
+      - pymorton

--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -1,5 +1,5 @@
 import uuid
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import dask
 
@@ -13,7 +13,7 @@ from shapely.geometry.base import BaseGeometry
 import geopandas
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely
 
-DASK_2021_06_0 = str(dask.__version__) >= LooseVersion("2021.06.0")
+DASK_2021_06_0 = Version(dask.__version__) >= Version("2021.06.0")
 
 if DASK_2021_06_0:
     from dask.dataframe.dispatch import make_meta_dispatch

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     "distributed>=2.18.0,!=2021.05.1",
     "numba",
     "pygeos",
+    "packaging",
 ]
 
 setup(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging.version import Version
 import pytest
 import pandas as pd
 import numpy as np
@@ -431,7 +431,7 @@ def test_propagate_on_set_crs(geodf_points):
 
 
 @pytest.mark.skipif(
-    LooseVersion(geopandas.__version__) <= LooseVersion("0.8.1"),
+    Version(geopandas.__version__) <= Version("0.8.1"),
     reason="geopandas 0.8 has bug in apply",
 )
 def test_geoseries_apply(geoseries_polygons):


### PR DESCRIPTION
`LooseVersion` is deprecated, replacing it with the recommended `packaging` alternative  as we did in https://github.com/geopandas/geopandas/pull/2084/