### PR TITLE
BUG: fix set_index issue with shuffle="disk"

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -478,6 +478,7 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         self.dask = new.dask
 
     def set_index(self, *args, **kwargs):
+        """Override to ensure we get GeoDataFrame with set geometry column"""
         ddf = super().set_index(*args, **kwargs)
         return ddf.set_geometry(self._meta.geometry.name)
 

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -477,6 +477,10 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         self._name = new._name
         self.dask = new.dask
 
+    def set_index(self, *args, **kwargs):
+        ddf = super().set_index(*args, **kwargs)
+        return ddf.set_geometry(self._meta.geometry.name)
+
     def set_geometry(self, col):
         # calculate ourselves to use meta and not meta_nonempty, which would
         # raise an error if meta is an invalid GeoDataFrame (e.g. geometry

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -480,6 +480,45 @@ def test_map_partitions_get_geometry(geodf_points):
     assert_geoseries_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "shuffle_method",
+    [
+        "disk",
+        "tasks",
+    ],
+)
+def test_set_index_preserves_class(geodf_points, shuffle_method):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    dask_obj = dask_obj.set_index("value1", shuffle=shuffle_method)
+
+    for partition in dask_obj.partitions:
+        assert isinstance(partition.compute(), geopandas.GeoDataFrame)
+
+    assert isinstance(dask_obj.compute(), geopandas.GeoDataFrame)
+
+
+@pytest.mark.parametrize(
+    "shuffle_method",
+    [
+        "disk",
+        "tasks",
+    ],
+)
+def test_set_index_preserves_class_and_name(geodf_points, shuffle_method):
+    df = geodf_points.rename_geometry("geom")
+    dask_obj = dask_geopandas.from_geopandas(df, npartitions=2)
+    dask_obj = dask_obj.set_index("value1", shuffle=shuffle_method)
+
+    for partition in dask_obj.partitions:
+        part = partition.compute()
+        assert isinstance(part, geopandas.GeoDataFrame)
+        assert part.geometry.name == "geom"
+
+    computed = dask_obj.compute()
+    assert isinstance(computed, geopandas.GeoDataFrame)
+    assert computed.geometry.name == "geom"
+
+
 def test_copy_none_spatial_partitions(geoseries_points):
     ddf = dask_geopandas.from_geopandas(geoseries_points, npartitions=2)
     ddf.spatial_partitions = None


### PR DESCRIPTION
Closes #59, closes #116

I initially started fixing this on the Dask side, trying to ensure that Dask preserves the subclass but realised that we would still need to do something on our side to ensure that a named geometry column is correctly assigned. Since Dask recreates a DataFrame from a dict, this is lost.
