### PR TITLE
CI: use mamba on CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,9 @@ jobs:
     needs: Linting
     name: ${{ matrix.os }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Test
         run: |
-          source activate test
           pytest -v -r s --color=yes --cov=dask_geopandas --cov-append --cov-report term-missing --cov-report xml .
 
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,6 @@ jobs:
           use-mamba: true
 
       - name: Check and Log Environment
-        shell: bash
         run: |
           python -V
           python -c "import geopandas; geopandas.show_versions();"
@@ -61,7 +60,6 @@ jobs:
           conda list
 
       - name: Test
-        shell: bash
         run: |
           source activate test
           pytest -v -r s --color=yes --cov=dask_geopandas --cov-append --cov-report term-missing --cov-report xml .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,18 +42,16 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-conda: false
-
-      - name: Install Env
-        shell: bash
-        run: conda env create -f ${{ matrix.env }}
+          environment-file: ${{ matrix.env }}
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Check and Log Environment
         shell: bash
         run: |
-          source activate test
           python -V
           python -c "import geopandas; geopandas.show_versions();"
           conda info
@@ -65,4 +63,4 @@ jobs:
           source activate test
           pytest -v -r s --color=yes --cov=dask_geopandas --cov-append --cov-report term-missing --cov-report xml .
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2

--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -8,6 +8,7 @@ dependencies:
   - numba
   - distributed
   - geopandas
+  - fiona
   - pygeos
   - pyproj=2.6
   - packaging


### PR DESCRIPTION
Use official `conda-incubator` action and mambaforge. The current setup is super slow, this should help it. It mirrors geopandas/geopandas settings.