### PR TITLE
ENH: match geopandas sjoin and clip API

### DIFF
--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -38,7 +38,10 @@ def clip(gdf, mask, keep_geom_type=False):
     }
     divisions = [None] * (len(dsk) + 1)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[gdf])
-    result = GeoDataFrame(graph, name, gdf._meta, tuple(divisions))
+    if isinstance(gdf, GeoDataFrame):
+        result = GeoDataFrame(graph, name, gdf._meta, tuple(divisions))
+    elif isinstance(gdf, GeoSeries):
+        result = GeoSeries(graph, name, gdf._meta, tuple(divisions))
     result.spatial_partitions = new_spatial_partitions
 
     return result

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -451,6 +451,10 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
         return geohashes
 
+    @derived_from(geopandas.GeoDataFrame)
+    def clip(self, mask, keep_geom_type=False):
+        return dask_geopandas.clip(self, mask=mask, keep_geom_type=keep_geom_type)
+
 
 class GeoSeries(_Frame, dd.core.Series):
     """Parallel GeoPandas GeoSeries
@@ -575,10 +579,6 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
             split_out=split_out,
         )
         return aggregated.set_crs(self.crs)
-
-    @derived_from(geopandas.GeoDataFrame)
-    def clip(self, mask, keep_geom_type=False):
-        return dask_geopandas.clip(self, mask=mask, keep_geom_type=keep_geom_type)
 
     def sjoin(self, df, how="inner", predicate="intersects"):
         """

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import geopandas
 
@@ -7,7 +9,7 @@ from dask.highlevelgraph import HighLevelGraph
 from .core import from_geopandas, GeoDataFrame
 
 
-def sjoin(left, right, how="inner", op="intersects"):
+def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
     """
     Spatial join of two GeoDataFrames.
 
@@ -19,7 +21,7 @@ def sjoin(left, right, how="inner", op="intersects"):
         partitioning information).
     how : string, default 'inner'
         The type of join. Currently only 'inner' is supported.
-    op : string, default 'intersects'
+    predicate : string, default 'intersects'
         Binary predicate how to match corresponding rows of the left and right
         GeoDataFrame. Possible values: 'contains', 'contains_properly',
         'covered_by', 'covers', 'crosses', 'intersects', 'overlaps',
@@ -38,6 +40,14 @@ def sjoin(left, right, how="inner", op="intersects"):
     all combinations (cartesian/cross product) of all input partition
     of the left and right GeoDataFrame.
     """
+    if "op" in kwargs:
+        predicate = kwargs.pop("op")
+        deprecation_message = (
+            "The `op` parameter is deprecated and will be removed"
+            " in a future release. Please use the `predicate` parameter"
+            " instead."
+        )
+        warnings.warn(deprecation_message, FutureWarning)
     if how != "inner":
         raise NotImplementedError("Only how='inner' is supported right now")
 
@@ -46,8 +56,8 @@ def sjoin(left, right, how="inner", op="intersects"):
     if isinstance(right, geopandas.GeoDataFrame):
         right = from_geopandas(right, npartitions=1)
 
-    name = "sjoin-" + tokenize(left, right, how, op)
-    meta = geopandas.sjoin(left._meta, right._meta, how=how, op=op)
+    name = "sjoin-" + tokenize(left, right, how, predicate)
+    meta = geopandas.sjoin(left._meta, right._meta, how=how, predicate=predicate)
 
     if left.spatial_partitions is not None and right.spatial_partitions is not None:
         # Spatial partitions are known -> use them to trim down the list of
@@ -73,7 +83,13 @@ def sjoin(left, right, how="inner", op="intersects"):
     dsk = {}
     new_spatial_partitions = []
     for i, (l, r) in enumerate(zip(parts_left, parts_right)):
-        dsk[(name, i)] = (geopandas.sjoin, (left._name, l), (right._name, r), how, op)
+        dsk[(name, i)] = (
+            geopandas.sjoin,
+            (left._name, l),
+            (right._name, r),
+            how,
+            predicate,
+        )
         # TODO preserve spatial partitions of the output if only left has spatial
         # partitions
         if using_spatial_partitions:

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -47,7 +47,7 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
             " in a future release. Please use the `predicate` parameter"
             " instead."
         )
-        warnings.warn(deprecation_message, FutureWarning)
+        warnings.warn(deprecation_message, FutureWarning, stacklevel=2)
     if how != "inner":
         raise NotImplementedError("Only how='inner' is supported right now")
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-geopandas
+geopandas>=0.10
 numpydoc
 sphinx-book-theme
 myst-nb

--- a/doc/source/docs/reference/geodataframe.rst
+++ b/doc/source/docs/reference/geodataframe.rst
@@ -47,6 +47,22 @@ Aggregating and exploding
 
    GeoDataFrame.explode
 
+Spatial joins
+-------------
+
+.. autosummary::
+   :toctree: api/
+
+   GeoDataFrame.sjoin
+
+Overlay operations
+------------------
+
+.. autosummary::
+   :toctree: api/
+
+   GeoDataFrame.clip
+
 Indexing
 --------
 

--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -124,6 +124,14 @@ Missing values
    GeoSeries.fillna
    GeoSeries.isna
 
+Overlay operations
+------------------
+
+.. autosummary::
+   :toctree: api/
+
+   GeoSeries.clip
+
 Indexing
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import versioneer
 
 install_requires = [
-    "geopandas",
+    "geopandas>=0.10",
     "dask>=2.18.0,!=2021.05.1",
     "distributed>=2.18.0,!=2021.05.1",
     "numba",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -512,6 +512,10 @@ def test_clip(geodf_points):
     result = dask_obj.clip(mask).compute()
     assert_geodataframe_equal(expected, result)
 
+    expected = geopandas.clip(geodf_points.geometry, mask)
+    result = dask_obj.geometry.clip(dask_obj.geometry, mask).compute()
+    assert_geoseries_equal(expected, result)
+
 
 class TestDissolve:
     def setup_method(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -512,8 +512,8 @@ def test_clip(geodf_points):
     result = dask_obj.clip(mask).compute()
     assert_geodataframe_equal(expected, result)
 
-    expected = geopandas.clip(geodf_points.geometry, mask)
-    result = dask_obj.geometry.clip(dask_obj.geometry, mask).compute()
+    expected = geodf_points.geometry.clip(mask)
+    result = dask_obj.geometry.clip(mask).compute()
     assert_geoseries_equal(expected, result)
 
 

--- a/tests/test_sjoin.py
+++ b/tests/test_sjoin.py
@@ -1,3 +1,5 @@
+import pytest
+
 import geopandas
 from geopandas.testing import assert_geodataframe_equal
 
@@ -13,24 +15,36 @@ def test_sjoin_dask_geopandas():
     )
     ddf_polygons = dask_geopandas.from_geopandas(df_polygons, npartitions=4)
 
-    expected = geopandas.sjoin(df_points, df_polygons, op="within", how="inner")
+    expected = geopandas.sjoin(df_points, df_polygons, predicate="within", how="inner")
     expected = expected.sort_index()
 
     # dask / geopandas
-    result = dask_geopandas.sjoin(ddf_points, df_polygons, op="within", how="inner")
+    result = dask_geopandas.sjoin(
+        ddf_points, df_polygons, predicate="within", how="inner"
+    )
     assert_geodataframe_equal(expected, result.compute().sort_index())
 
     # geopandas / dask
-    result = dask_geopandas.sjoin(df_points, ddf_polygons, op="within", how="inner")
+    result = dask_geopandas.sjoin(
+        df_points, ddf_polygons, predicate="within", how="inner"
+    )
     assert_geodataframe_equal(expected, result.compute().sort_index())
 
     # dask / dask
-    result = dask_geopandas.sjoin(ddf_points, ddf_polygons, op="within", how="inner")
+    result = dask_geopandas.sjoin(
+        ddf_points, ddf_polygons, predicate="within", how="inner"
+    )
     assert_geodataframe_equal(expected, result.compute().sort_index())
 
     # with spatial_partitions
     ddf_points.calculate_spatial_partitions()
     ddf_polygons.calculate_spatial_partitions()
-    result = dask_geopandas.sjoin(ddf_points, ddf_polygons, op="within", how="inner")
+    result = dask_geopandas.sjoin(
+        ddf_points, ddf_polygons, predicate="within", how="inner"
+    )
     assert result.spatial_partitions is not None
     assert_geodataframe_equal(expected, result.compute().sort_index())
+
+    # check warning
+    with pytest.warns(FutureWarning, match="The `op` parameter is deprecated"):
+        dask_geopandas.sjoin(df_points, ddf_polygons, op="within", how="inner")


### PR DESCRIPTION
Closes #127, xref #130

- add `clip` as a GeoDataFrame method
- support GeoSeries in `clip` and add it the method
- add `sjoin` as a GeoDataFrame method
- change `op` to `predicate` in `sjoin`