### PR TITLE
CI: use strict channel priority to avoid GDAL from main channel

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,7 @@ jobs:
           miniforge-version: latest
           miniforge-variant: Mambaforge
           use-mamba: true
+          channel-priority: strict
 
       - name: Check and Log Environment
         run: |


### PR DESCRIPTION
The tests on python 3.7 are currently failing due to a fiona import error (https://github.com/geopandas/dask-geopandas/runs/5123735878?check_suite_focus=true), which I suppose is caused by a mix from default / conda-forge channel (for some reason, it started to install GDAL 3.4 from the main channel instead of GDAL 3.2 from conda-forge, since one of the last days)