### PR TITLE
BUG: ensure clip returns partitions as GeoSeries

### DIFF
--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -23,7 +23,7 @@ def clip(gdf, mask, keep_geom_type=False):
         )
 
     new_spatial_partitions = geopandas.clip(
-        gdf=gdf.spatial_partitions.to_frame("geometry"),
+        gdf=gdf.spatial_partitions,
         mask=mask,
         # keep_geom_type is always false for clipping the spatial partitions
         # otherwise we'd be falsely creating new partition(s)


### PR DESCRIPTION
Closes #152 

I am not sure why we had `.to_frame("geometry")` in there but it is not needed. 

I have also changed one test to use real world data because that fixture returns LineStrings as partitions since all points are in line (I don't that that it is an issue by itself).