### PR TITLE
ENH: raise for empty geoms in sorting methods

### DIFF
--- a/dask_geopandas/geohash.py
+++ b/dask_geopandas/geohash.py
@@ -8,6 +8,8 @@ The vectorized implementation for quantization and bit interleaving is in turn b
 "Geohash in Golang Assembly" blog (https://mmcloughlin.com/posts/geohash-assembly).
 
 """
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -31,6 +33,15 @@ def _geohash(gdf, as_string, precision):
     type : pandas.Series
         Series containing geohash
     """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "GeoSeries.isna() previously returned True", UserWarning
+        )
+        if gdf.is_empty.any() | gdf.geometry.isna().any():
+            raise ValueError(
+                "Geohash cannot be computed on a GeoSeries with empty or "
+                "missing geometries.",
+            )
 
     # Calculate bounds
     bounds = gdf.bounds.to_numpy()

--- a/dask_geopandas/hilbert_distance.py
+++ b/dask_geopandas/hilbert_distance.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -24,6 +26,15 @@ def _hilbert_distance(gdf, total_bounds=None, level=16):
     Pandas Series containing distances along the Hilbert curve
 
     """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "GeoSeries.isna() previously returned True", UserWarning
+        )
+        if gdf.is_empty.any() | gdf.geometry.isna().any():
+            raise ValueError(
+                "Hilbert distance cannot be computed on a GeoSeries with empty or "
+                "missing geometries.",
+            )
     # Calculate bounds as numpy array
     bounds = gdf.bounds.to_numpy()
 

--- a/dask_geopandas/morton_distance.py
+++ b/dask_geopandas/morton_distance.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
 
@@ -22,6 +24,15 @@ def _morton_distance(gdf, total_bounds, level):
         Series containing distances from Morton curve
 
     """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", "GeoSeries.isna() previously returned True", UserWarning
+        )
+        if gdf.is_empty.any() | gdf.geometry.isna().any():
+            raise ValueError(
+                "Morton distance cannot be computed on a GeoSeries with empty or "
+                "missing geometries.",
+            )
     # Calculate bounds as numpy array
     bounds = gdf.bounds.to_numpy()
     # Calculate discrete coords based on total bounds and bounds

--- a/tests/test_morton_distance.py
+++ b/tests/test_morton_distance.py
@@ -6,6 +6,7 @@ from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
 from dask_geopandas import from_geopandas
 import geopandas
 from shapely.geometry import Point, LineString, Polygon
+from shapely.wkt import loads
 
 
 @pytest.fixture
@@ -81,3 +82,20 @@ def test_world():
     morton_distance_dask(
         geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres")).iloc[1:]
     )
+
+
+@pytest.mark.parametrize(
+    "empty",
+    [
+        None,
+        loads("POLYGON EMPTY"),
+    ],
+)
+def test_empty(geoseries_polygons, empty):
+    s = geoseries_polygons
+    s.iloc[-1] = empty
+    dask_obj = from_geopandas(s, npartitions=2)
+    with pytest.raises(
+        ValueError, match="cannot be computed on a GeoSeries with empty"
+    ):
+        dask_obj.morton_distance().compute()


### PR DESCRIPTION
Closes #146

Check for empty or missing geometry and raise `ValueError` instead of returning 0 in `hilbert_distance`, `morton_distance` and `geohash`.