### PR TITLE
DEP: bump dask minimum required version to 2021.06.0

### DIFF
--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.7
-  - dask=2.18
+  - dask=2021.06.0
   - distributed
   - geopandas
   - fiona

--- a/continuous_integration/envs/37-latest.yaml
+++ b/continuous_integration/envs/37-latest.yaml
@@ -8,6 +8,7 @@ dependencies:
   - distributed
   - geopandas
   - fiona
+  - gdal=3.2.1
   - pygeos
   - pyproj=2.6
   - packaging

--- a/continuous_integration/envs/38-latest.yaml
+++ b/continuous_integration/envs/38-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.8
-  - dask=2021.05.0
+  - dask=2021.11.0
   - distributed
   - geopandas
   - pygeos

--- a/dask_geopandas/__init__.py
+++ b/dask_geopandas/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "GeoSeries",
     "from_geopandas",
     "from_dask_dataframe",
+    "read_file",
     "read_feather",
     "read_parquet",
     "to_feather",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import versioneer
 
 install_requires = [
     "geopandas>=0.10",
-    "dask>=2.18.0,!=2021.05.1",
-    "distributed>=2.18.0,!=2021.05.1",
+    "dask>=2021.06.0",
+    "distributed>=2021.06.0",
     "pygeos",
     "packaging",
 ]


### PR DESCRIPTION
See https://github.com/geopandas/dask-geopandas/pull/163#issuecomment-1039452906

With the latest changes of https://github.com/geopandas/dask-geopandas/pull/91, we accidentally started to require dask 2021.5.0. So one option to deal with this is to simply bump the minimum required version (I directly bumped to 2021.06.0, because we already disallow 2021.05.1)