### PR TITLE
CI: add test env with no optional dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         env:
-          - continuous_integration/envs/37-latest.yaml
+          - continuous_integration/envs/39-no-optional-deps.yaml
+          - continuous_integration/envs/37-minimal.yaml
           - continuous_integration/envs/38-latest.yaml
           - continuous_integration/envs/39-latest.yaml
 

--- a/continuous_integration/envs/37-minimal.yaml
+++ b/continuous_integration/envs/37-minimal.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.7
   - dask=2021.06.0
   - distributed
-  - geopandas
+  - geopandas=0.10
   - fiona
   - gdal=3.2.1
   - pygeos
@@ -16,8 +16,9 @@ dependencies:
   - pytest
   - pytest-cov
   - hilbertcurve
-  # optional dependencies
   - pygeohash
+  # optional dependencies
+  - pyarrow
   - pip
   - pip:
       - pymorton

--- a/continuous_integration/envs/39-no-optional-deps.yaml
+++ b/continuous_integration/envs/39-no-optional-deps.yaml
@@ -1,0 +1,20 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.9
+  - dask
+  - distributed
+  - geopandas
+  - pygeos
+  - pyproj
+  - packaging
+  # test dependencies
+  - pytest
+  - pytest-cov
+  - hilbertcurve
+  - pygeohash
+  - pip
+  - pip:
+      - pymorton

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -1,5 +1,8 @@
+from packaging.version import Version
+
 import geopandas
 import dask_geopandas
+import dask
 import dask.dataframe as dd
 
 import pytest
@@ -158,6 +161,10 @@ def test_parquet_empty_partitions(tmp_path):
     assert result.spatial_partitions is None
 
 
+@pytest.mark.skipif(
+    Version(dask.__version__) < Version("2021.10.0"),
+    reason="Only correct error message with dask 2021.10.0 or up",
+)
 def test_parquet_empty_dataset(tmp_path):
     # ensure informative error message if there are no parts (otherwise
     # will raise in not finding any geo metadata)


### PR DESCRIPTION
Now we have both pyarrow and pyogrio as optional dependencies for IO, we should ensure we don't accidentally make them required dependencies by importing them unconditionally. Copying the testing approach from geopandas.