### PR TITLE
DOC: Update spatial_shuffle level using default level 16

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -710,7 +710,7 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
             details.
         level : int (default None)
             Level (precision) of the  Hilbert and Morton
-            curves used as a sorting method. Defaults to 15. Does not have an effect for
+            curves used as a sorting method. Defaults to 16. Does not have an effect for
             the ``'geohash'`` option.
         calculate_partitions : bool (default True)
             Calculate new spatial partitions after shuffling


### PR DESCRIPTION
The current docstring for `spatial_shuffle` incorrectly asserts that the the default level is 15.
This should be 16.