### PR TITLE
Set divisions and index in read_file

### DIFF
--- a/dask_geopandas/tests/io/test_file.py
+++ b/dask_geopandas/tests/io/test_file.py
@@ -63,9 +63,7 @@ def test_read_file_columns():
     assert result.npartitions == 4
     assert result.crs == df.crs
     assert len(result.columns) == 2
-    assert_geodataframe_equal(
-        result.compute(), df[["pop_est", "geometry"]]
-    )
+    assert_geodataframe_equal(result.compute(), df[["pop_est", "geometry"]])
     # only selecting non-geometry column
     result = dask_geopandas.read_file(path, npartitions=4, columns=["pop_est"])
     assert type(result) == dd.DataFrame


### PR DESCRIPTION
Fix #179 

This sets division when creating the dataframe and sets the resulting
index to RangeIndex for each partition using the appropriate offsets for
each parition.