### PR TITLE
BUG: persist spatial_partitions information in persist()

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -65,7 +65,17 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
         return _finalize, ()
 
     def __dask_postpersist__(self):
-        return type(self), (self._name, self._meta, self.divisions)
+        return self._rebuild, ()
+
+    def _rebuild(self, dsk, *, rename=None):
+        # this is a copy of the dask.dataframe version, only with the addition
+        # to pass self.spatial_partitions
+        name = self._name
+        if rename:
+            name = rename.get(name, name)
+        return type(self)(
+            dsk, name, self._meta, self.divisions, self.spatial_partitions
+        )
 
     @property
     def spatial_partitions(self):

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -468,6 +468,15 @@ def test_copy_spatial_partitions(geodf_points):
     )
 
 
+def test_persist_spatial_partitions(geodf_points):
+    dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
+    dask_obj.calculate_spatial_partitions()
+    dask_obj_persisted = dask_obj.persist()
+    pd.testing.assert_series_equal(
+        dask_obj.spatial_partitions, dask_obj_persisted.spatial_partitions
+    )
+
+
 def test_set_crs_sets_spatial_partition_crs(geodf_points):
     dask_obj = dask_geopandas.from_geopandas(geodf_points, npartitions=2)
 


### PR DESCRIPTION
While looking at the custom collection dask dunder methods (for https://github.com/geopandas/dask-geopandas/pull/191), I noticed that our custom `__dask_postpersist__` is a bit outdated (since https://github.com/dask/dask/pull/7276 it should have a `rename` keyword) and that it lacks any handling of spatial_partitions.

So this PR updates it with the upstream version + passes through `spatial_partitions`