### PR TITLE
Optionally skip spatial bounds in read_parquet

### DIFF
--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -50,13 +50,16 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     def read_metadata(cls, fs, paths, **kwargs):
         meta, stats, parts, index = super().read_metadata(fs, paths, **kwargs)
 
-        # get spatial partitions if available
-        regions = geopandas.GeoSeries(
-            [_get_partition_bounds_parquet(part, fs) for part in parts], crs=meta.crs
-        )
-        if regions.notna().all():
-            # a bit hacky, but this allows us to get this passed through
-            meta.attrs["spatial_partitions"] = regions
+        gather_spatial_partitions = kwargs.pop("gather_spatial_partitions", True)
+
+        if gather_spatial_partitions:
+            regions = geopandas.GeoSeries(
+                [_get_partition_bounds_parquet(part, fs) for part in parts],
+                crs=meta.crs,
+            )
+            if regions.notna().all():
+                # a bit hacky, but this allows us to get this passed through
+                meta.attrs["spatial_partitions"] = regions
 
         return (meta, stats, parts, index)
 

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -50,9 +50,9 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     def read_metadata(cls, fs, paths, **kwargs):
         meta, stats, parts, index = super().read_metadata(fs, paths, **kwargs)
 
-        gather_spatial_partitions = kwargs.pop("gather_spatial_partitions", True)
+        calculate_spatial_partitions = kwargs.pop("calculate_spatial_partitions", True)
 
-        if gather_spatial_partitions:
+        if calculate_spatial_partitions:
             regions = geopandas.GeoSeries(
                 [_get_partition_bounds_parquet(part, fs) for part in parts],
                 crs=meta.crs,

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -50,9 +50,9 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     def read_metadata(cls, fs, paths, **kwargs):
         meta, stats, parts, index = super().read_metadata(fs, paths, **kwargs)
 
-        calculate_spatial_partitions = kwargs.pop("calculate_spatial_partitions", True)
+        gather_spatial_partitions = kwargs.pop("gather_spatial_partitions", True)
 
-        if calculate_spatial_partitions:
+        if gather_spatial_partitions:
             regions = geopandas.GeoSeries(
                 [_get_partition_bounds_parquet(part, fs) for part in parts],
                 crs=meta.crs,

--- a/dask_geopandas/tests/io/test_parquet.py
+++ b/dask_geopandas/tests/io/test_parquet.py
@@ -203,3 +203,16 @@ def test_parquet_partition_on(tmp_path, write_metadata_file):
     expected = df.copy()
     expected["continent"] = expected["continent"].astype("category")
     assert_geodataframe_equal(result.compute(), expected, check_like=True)
+
+
+def test_no_gather_spatial_partitions(tmp_path):
+    # basic roundtrip
+    df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    ddf = dask_geopandas.from_geopandas(df, npartitions=4)
+
+    basedir = tmp_path / "dataset"
+    ddf.to_parquet(basedir)
+
+    result = dask_geopandas.read_parquet(basedir, gather_spatial_partitions=False)
+    assert result.spatial_partitions is None
+    assert result.crs == df.crs

--- a/dask_geopandas/tests/io/test_parquet.py
+++ b/dask_geopandas/tests/io/test_parquet.py
@@ -205,7 +205,7 @@ def test_parquet_partition_on(tmp_path, write_metadata_file):
     assert_geodataframe_equal(result.compute(), expected, check_like=True)
 
 
-def test_no_gather_spatial_partitions(tmp_path):
+def test_no_calculate_spatial_partitions(tmp_path):
     # basic roundtrip
     df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     ddf = dask_geopandas.from_geopandas(df, npartitions=4)
@@ -213,6 +213,6 @@ def test_no_gather_spatial_partitions(tmp_path):
     basedir = tmp_path / "dataset"
     ddf.to_parquet(basedir)
 
-    result = dask_geopandas.read_parquet(basedir, gather_spatial_partitions=False)
+    result = dask_geopandas.read_parquet(basedir, calculate_spatial_partitions=False)
     assert result.spatial_partitions is None
     assert result.crs == df.crs

--- a/dask_geopandas/tests/io/test_parquet.py
+++ b/dask_geopandas/tests/io/test_parquet.py
@@ -205,7 +205,7 @@ def test_parquet_partition_on(tmp_path, write_metadata_file):
     assert_geodataframe_equal(result.compute(), expected, check_like=True)
 
 
-def test_no_calculate_spatial_partitions(tmp_path):
+def test_no_gather_spatial_partitions(tmp_path):
     # basic roundtrip
     df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
     ddf = dask_geopandas.from_geopandas(df, npartitions=4)
@@ -213,6 +213,6 @@ def test_no_calculate_spatial_partitions(tmp_path):
     basedir = tmp_path / "dataset"
     ddf.to_parquet(basedir)
 
-    result = dask_geopandas.read_parquet(basedir, calculate_spatial_partitions=False)
+    result = dask_geopandas.read_parquet(basedir, gather_spatial_partitions=False)
     assert result.spatial_partitions is None
     assert result.crs == df.crs

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -55,6 +55,7 @@ hidden: true
 installation
 getting_started
 guide
+parquet
 api
 GitHub <https://github.com/geopandas/dask-geopandas>
 ```

--- a/doc/source/parquet.md
+++ b/doc/source/parquet.md
@@ -13,10 +13,10 @@ persisted in the parquet files.
 
 By default, reading these spatial partitions requires opening every file and checking its spatial extent. This can be a
 bit slow if the parquet dataset is made up of many individual partitions. To disable loading the spatial partitions,
-specify ``calculate_spatial_partitions=False`` when reading the file:
+specify ``gather_spatial_partitions=False`` when reading the file:
 
 
 ```py
-ddf = dask_geopandas.read_parquet("...", calculate_spatial_partitions=False)
+ddf = dask_geopandas.read_parquet("...", gather_spatial_partitions=False)
 ddf.spatial_partitions  # None
 ```

--- a/doc/source/parquet.md
+++ b/doc/source/parquet.md
@@ -13,10 +13,10 @@ persisted in the parquet files.
 
 By default, reading these spatial partitions requires opening every file and checking its spatial extent. This can be a
 bit slow if the parquet dataset is made up of many individual partitions. To disable loading the spatial partitions,
-specify ``gather_spatial_partitions=False`` when reading the file:
+specify ``calculate_spatial_partitions=False`` when reading the file:
 
 
 ```py
-ddf = dask_geopandas.read_parquet("...", gather_spatial_partitions=False)
+ddf = dask_geopandas.read_parquet("...", calculate_spatial_partitions=False)
 ddf.spatial_partitions  # None
 ```

--- a/doc/source/parquet.md
+++ b/doc/source/parquet.md
@@ -1,0 +1,22 @@
+# Reading and Writing Apache Parquet
+
+Similar to dask-dataframe, dask-geopandas supports reading and writing Apache Parquet files.
+
+See the [Dask DataFrame](https://docs.dask.org/en/stable/dataframe-parquet.html#dataframe-parquet) 
+and [Geopandas](https://geopandas.org/en/stable/docs/user_guide/io.html#apache-parquet-and-feather-file-formats) documentation
+for more on Apache Parquet.
+
+## Partitioning
+
+As outlined in :doc:`guide/spatial-partitioning`, dask-geopandas can spatially partition datasets. These partitions are
+persisted in the parquet files.
+
+By default, reading these spatial partitions requires opening every file and checking its spatial extent. This can be a
+bit slow if the parquet dataset is made up of many individual partitions. To disable loading the spatial partitions,
+specify ``gather_spatial_partitions=False`` when reading the file:
+
+
+```py
+ddf = dask_geopandas.read_parquet("...", gather_spatial_partitions=False)
+ddf.spatial_partitions  # None
+```


### PR DESCRIPTION
Adds a new `gather_spatial_partitions` keyword to `read_parquet`
to disable opening each file to get its spatial bounds. The name was
chosen to mimic dask's `gather_statistics` keyword.

Also adds a small docs section (I didn't see an easy way to
insert a snippet in the docstring).

Closes https://github.com/geopandas/dask-geopandas/issues/194.

---

One note of hesitation: I think Dask mid-transition for handling how it reads metadata. I'm wondering whether we should just rely on the behavior of dask's `gather_statistics` keyword. IIUC, both it and this new `gather_spatial_partitions` control whether there's a *per-file* operation in `read_parquet`.

Maybe @jcrist or @rjzamora have a recommendation on whether adding a new keyword here is going against where Dask is headed.