### PR TITLE
MAINT: use predicate instead of op in sjoin internals

### DIFF
--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -66,7 +66,7 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
             left.spatial_partitions.to_frame("geometry"),
             right.spatial_partitions.to_frame("geometry"),
             how="inner",
-            op="intersects",
+            predicate="intersects",
         )
         parts_left = np.asarray(parts.index)
         parts_right = np.asarray(parts["index_right"].values)


### PR DESCRIPTION
We have one forgotten `op` inside our `sjoin` here, rasing a warning that is not fixable by a user.