### PR TITLE
Don't put GeoSeries in `map_partitions` kwarg

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -778,6 +778,15 @@ def from_dask_dataframe(df, geometry=None):
         the values will be set as 'geometry' column on the GeoDataFrame.
 
     """
+    # If the geometry column is already a partitioned `_Frame`, we can't refer to
+    # it via a keyword-argument due to https://github.com/dask/dask/issues/8308.
+    # Instead, we assign the geometry column using regular dataframe operations,
+    # then refer to that column by name in `map_partitions`.
+    if isinstance(geometry, _Frame):
+        name = geometry.name or "geometry"
+        return df.assign(**{name: geometry}).map_partitions(
+            geopandas.GeoDataFrame, geometry=name
+        )
     return df.map_partitions(geopandas.GeoDataFrame, geometry=geometry)
 
 


### PR DESCRIPTION
Workaround for the fact that we can't include a partitioned `_Frame` in the keyword arguments for `map_partitions without it being concatenated on a single worker.

Fixes #197 