### PR TITLE
BUG: convert spatial partitions to geoseries in sjoin result

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -46,7 +46,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
 
     def __init__(self, dsk, name, meta, divisions, spatial_partitions=None):
         super().__init__(dsk, name, meta, divisions)
-        self._spatial_partitions = spatial_partitions
+        self.spatial_partitions = spatial_partitions
 
     def to_dask_dataframe(self):
         """Create a dask.dataframe object from a dask_geopandas object"""

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -102,7 +102,8 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
     divisions = [None] * (len(dsk) + 1)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[left, right])
     if using_spatial_partitions:
-        new_spatial_partitions = geopandas.GeoSeries(data=new_spatial_partitions)
+        new_spatial_partitions = geopandas.GeoSeries(data=new_spatial_partitions,
+                                                     crs=left.crs)
     else:
         new_spatial_partitions = None
 

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -102,8 +102,9 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
     divisions = [None] * (len(dsk) + 1)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[left, right])
     if using_spatial_partitions:
-        new_spatial_partitions = geopandas.GeoSeries(data=new_spatial_partitions,
-                                                     crs=left.crs)
+        new_spatial_partitions = geopandas.GeoSeries(
+            data=new_spatial_partitions, crs=left.crs
+        )
     else:
         new_spatial_partitions = None
 

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -101,6 +101,9 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
 
     divisions = [None] * (len(dsk) + 1)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[left, right])
-    if not using_spatial_partitions:
+    if using_spatial_partitions:
+        new_spatial_partitions = geopandas.GeoSeries(data=new_spatial_partitions)
+    else:
         new_spatial_partitions = None
+
     return GeoDataFrame(graph, name, meta, divisions, new_spatial_partitions)

--- a/dask_geopandas/tests/test_sjoin.py
+++ b/dask_geopandas/tests/test_sjoin.py
@@ -42,7 +42,7 @@ def test_sjoin_dask_geopandas():
     result = dask_geopandas.sjoin(
         ddf_points, ddf_polygons, predicate="within", how="inner"
     )
-    assert result.spatial_partitions is not None
+    assert isinstance(result.spatial_partitions, geopandas.GeoSeries)
     assert_geodataframe_equal(expected, result.compute().sort_index())
 
     # check warning


### PR DESCRIPTION
* make sure 'core.py' does not skip self.spatial_partitions quality check by removing hidden function bypass
* add conversion to geoseries in `sjoin.py'