### PR TITLE
Handle larger than 32bit distances when creating Hilbert distance and spatially partitioning.

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -389,7 +389,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
             _hilbert_distance,
             total_bounds=total_bounds,
             level=level,
-            meta=pd.Series([], name="hilbert_distance", dtype="uint32"),
+            meta=pd.Series([], name="hilbert_distance", dtype=np.int64),
         )
 
         return distances

--- a/dask_geopandas/hilbert_distance.py
+++ b/dask_geopandas/hilbert_distance.py
@@ -43,7 +43,7 @@ def _hilbert_distance(gdf, total_bounds=None, level=16):
     # Compute distance along hilbert curve
     distances = _encode(level, x, y)
 
-    return pd.Series(distances, index=gdf.index, name="hilbert_distance")
+    return pd.Series(distances, index=gdf.index, name="hilbert_distance", dtype=np.int64)
 
 
 def _continuous_to_discrete_coords(bounds, level, total_bounds):

--- a/dask_geopandas/tests/test_spatial_partitioning.py
+++ b/dask_geopandas/tests/test_spatial_partitioning.py
@@ -1,9 +1,12 @@
+import numpy as np
 import pytest
 
 import geopandas
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from shapely.geometry import Point
 
 import dask_geopandas
+from dask_geopandas.hilbert_distance import _hilbert_distance
 
 
 def test_propagate_on_geometry_access():
@@ -60,3 +63,18 @@ def test_cx():
     assert len(subset) == 0
     expected = df.cx[-200:-190, 300:400]
     assert_geodataframe_equal(subset.compute(), expected)
+
+
+def test_geopandas_handles_large_hilbert_distances():
+    df = geopandas.GeoDataFrame(
+        {
+            'geometry': [Point(-103152.516, -8942.156), Point(118914.500, 1010032.562)]
+        }
+    )
+
+    # make sure we have values greater than 32bits
+    dist = _hilbert_distance(df)
+    assert ((dist > np.iinfo(np.int32).max) | (dist < np.iinfo(np.int32).min)).any()
+
+    ddf = dask_geopandas.from_geopandas(df, npartitions=1)
+    ddf.spatial_shuffle()


### PR DESCRIPTION
I have come across an issue with spatially partitioning data where the distance between geometry as calculated by hilbert_distance is greater than a 32bit integer. The meta for the returned series is set to 32bit which causes dask to cast down to 32bit when setting index, this causes an overflow and the resulting divisions being out of order. Here is a minimal example to show the issue.

```python
import geopandas as gpd
import dask_geopandas as dgpd
from shapely.geometry import Point

df = gpd.GeoDataFrame({
    'geometry': [Point(-103152.516, -8942.156), Point(118914.500, 1010032.562)]
})

ddf = dgpd.from_geopandas(df, npartitions=2)
ddf.spatial_shuffle()
```

setting correctly to int64 before passing to dask fixes this issue.

```python
from dask.dataframe.shuffle import set_index
import numpy as np

by = ddf.hilbert_distance()
set_index(ddf, by.astype(np.int64)).compute()
```

It should be a simple fix to handle these cases, so I've gone ahead and created a branch for your review.