### PR TITLE
COMPAT: specify shuffle=False in dissolve

### DIFF
--- a/continuous_integration/envs/310-latest.yaml
+++ b/continuous_integration/envs/310-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.10
-  - dask=2022.06.0
+  - dask=2022.10.0
   - distributed
   - geopandas
   - pygeos

--- a/continuous_integration/envs/39-no-optional-deps.yaml
+++ b/continuous_integration/envs/39-no-optional-deps.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.9
-  - dask=2022.5.2
+  - dask=2022.6.0
   - distributed
   - geopandas
   - pygeos

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -641,6 +641,7 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         aggregated = self.groupby(by=by, **kwargs).agg(
             data_agg,
             split_out=split_out,
+            shuffle=False,
         )
         return aggregated.set_crs(self.crs)
 

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -1,6 +1,9 @@
+from packaging.version import Version
+
 import numpy as np
 import pandas as pd
 
+import dask
 import dask.dataframe as dd
 import dask.array as da
 from dask.dataframe.core import _emulate, map_partitions, elemwise, new_dd_object
@@ -18,6 +21,9 @@ from .morton_distance import _morton_distance
 from .geohash import _geohash
 
 import dask_geopandas
+
+
+DASK_2022_8_1 = Version(dask.__version__) >= Version("2022.8.1")
 
 
 def _set_crs(df, crs, allow_override):
@@ -638,10 +644,12 @@ class GeoDataFrame(_Frame, dd.core.DataFrame):
         else:
             data_agg = {col: aggfunc for col in self.columns.drop(drop)}
         data_agg[self.geometry.name] = merge_geometries
+        # dask 2022.8.1 added shuffle keyword, enabled by default if split_out > 1
+        # starting with dask 2022.9.1, but geopandas doesn't yet work with shuffle
+        # https://github.com/geopandas/dask-geopandas/pull/229
+        agg_kwargs = {"shuffle": False} if DASK_2022_8_1 else {}
         aggregated = self.groupby(by=by, **kwargs).agg(
-            data_agg,
-            split_out=split_out,
-            shuffle=False,
+            data_agg, split_out=split_out, **agg_kwargs
         )
         return aggregated.set_crs(self.crs)
 


### PR DESCRIPTION
On top of https://github.com/geopandas/dask-geopandas/pull/228 (will rebase this once the other is merged)

Starting with dask 2022.9.1, groupby started to use shuffle by default with `split_out>1`, see https://github.com/dask/dask/pull/9453

But doing that currently doesn't work (at least with the test case). It comes down to `_meta_nonempty` failing to be determined, an issue with renamed columns and then the GeoDataFrame constructor fails with that:

https://github.com/geopandas/dask-geopandas/blob/bd355404dad23c8a1a5876834f569d54d85fc626/dask_geopandas/backends.py#L60-L63

First, it raises "The CRS attribute of a GeoDataFrame without an active geometry column is not defined. Use GeoDataFrame.set_geometry to set the active geometry column.", and after removing `crs=x.crs`, it raises "ValueError: Unknown column geometry" because the groupby shuffle renamed the columns

(I remember we ran into similar issues before, but not fully sure anymore if we solved that / where this discussion is)