### PR TITLE
BUG: fix `read_parquet` with `dask>=2022.12.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         language_version: python3

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -128,10 +128,7 @@ class ArrowDatasetEngine:
 
     @classmethod
     def _arrow_table_to_pandas(
-        cls,
-        arrow_table: "pyarrow.Table",
-        categories,
-        **kwargs,
+        cls, arrow_table: "pyarrow.Table", categories, **kwargs
     ) -> pd.DataFrame:
 
         _kwargs = kwargs.get("arrow_to_pandas", {})

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -1,7 +1,10 @@
 import copy
 import json
 import math
+from packaging.version import Version
 from typing import TYPE_CHECKING
+
+import dask
 
 from dask.base import compute_as_if_collection, tokenize
 from dask.dataframe.core import new_dd_object, Scalar
@@ -14,6 +17,8 @@ import geopandas
 import shapely.geometry
 
 from fsspec.core import get_fs_token_paths
+
+DASK_2022_12_0_PLUS = Version(dask.__version__) >= Version("2022.12.0")
 
 
 if TYPE_CHECKING:
@@ -121,14 +126,51 @@ class ArrowDatasetEngine:
 
         return fragments, meta, schema, filter
 
-    @classmethod
-    def _arrow_table_to_pandas(
-        cls, arrow_table: "pyarrow.Table", categories, **kwargs
-    ) -> pd.DataFrame:
-        _kwargs = kwargs.get("arrow_to_pandas", {})
-        _kwargs.update({"use_threads": False, "ignore_metadata": False})
+    if DASK_2022_12_0_PLUS:
 
-        return arrow_table.to_pandas(categories=categories, **_kwargs)
+        @classmethod
+        def _arrow_table_to_pandas(
+            cls,
+            arrow_table: "pyarrow.Table",
+            categories,
+            use_nullable_dtypes=False,
+            **kwargs,
+        ) -> pd.DataFrame:
+            from dask.dataframe.io.parquet.arrow import PYARROW_NULLABLE_DTYPE_MAPPING
+
+            _kwargs = kwargs.get("arrow_to_pandas", {})
+            _kwargs.update({"use_threads": False, "ignore_metadata": False})
+
+            if use_nullable_dtypes:
+                if "types_mapper" in _kwargs:
+                    # User-provided entries take priority over PYARROW_NULLABLE_DTYPE_MAPPING
+                    types_mapper = _kwargs["types_mapper"]
+
+                    def _types_mapper(pa_type):
+                        return types_mapper(
+                            pa_type
+                        ) or PYARROW_NULLABLE_DTYPE_MAPPING.get(pa_type)
+
+                    _kwargs["types_mapper"] = _types_mapper
+
+                else:
+                    _kwargs["types_mapper"] = PYARROW_NULLABLE_DTYPE_MAPPING.get
+
+            return arrow_table.to_pandas(categories=categories, **_kwargs)
+
+    else:
+
+        @classmethod
+        def _arrow_table_to_pandas(
+            cls,
+            arrow_table: "pyarrow.Table",
+            categories,
+            **kwargs,
+        ) -> pd.DataFrame:
+            _kwargs = kwargs.get("arrow_to_pandas", {})
+            _kwargs.update({"use_threads": False, "ignore_metadata": False})
+
+            return arrow_table.to_pandas(categories=categories, **_kwargs)
 
     @classmethod
     def read_partition(cls, fs, fragment, schema, columns, filter, **kwargs):

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -220,6 +220,13 @@ class GeoDatasetEngine:
                 return super()._arrow_table_to_pandas(
                     arrow_table, categories=categories, **kwargs
                 )
+            # when there are no columns, we also fall back (the dataset might
+            # have no files, and so we don't want to raise a confusing error
+            # about no geometry column)
+            elif not arrow_table.schema.names:
+                return super()._arrow_table_to_pandas(
+                    arrow_table, categories=categories, **kwargs
+                )
             else:
                 raise
 

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -84,37 +84,23 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
         meta = cls._update_meta(meta, schema)
         return meta, index_cols, categories, index, partition_info
 
-    if DASK_2022_12_0_PLUS:
-
-        @classmethod
-        def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
-            """Overriding private method for dask >= 2021.10.0"""
+    @classmethod
+    def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
+        """Overriding private method for dask >= 2021.10.0"""
+        if DASK_2022_12_0_PLUS:
             meta = super()._create_dd_meta(dataset_info, use_nullable_dtypes)
-            schema = dataset_info["schema"]
-            if not schema.names and not schema.metadata:
-                if len(list(dataset_info["ds"].get_fragments())) == 0:
-                    raise ValueError(
-                        "No dataset parts discovered. Use dask.dataframe.read_parquet "
-                        "to read it as an empty DataFrame"
-                    )
-            meta = cls._update_meta(meta, schema)
-            return meta
-
-    else:
-
-        @classmethod
-        def _create_dd_meta(cls, dataset_info):
-            """Overriding private method for dask >= 2021.10.0"""
+        else:
             meta = super()._create_dd_meta(dataset_info)
-            schema = dataset_info["schema"]
-            if not schema.names and not schema.metadata:
-                if len(list(dataset_info["ds"].get_fragments())) == 0:
-                    raise ValueError(
-                        "No dataset parts discovered. Use dask.dataframe.read_parquet "
-                        "to read it as an empty DataFrame"
-                    )
-            meta = cls._update_meta(meta, schema)
-            return meta
+
+        schema = dataset_info["schema"]
+        if not schema.names and not schema.metadata:
+            if len(list(dataset_info["ds"].get_fragments())) == 0:
+                raise ValueError(
+                    "No dataset parts discovered. Use dask.dataframe.read_parquet "
+                    "to read it as an empty DataFrame"
+                )
+        meta = cls._update_meta(meta, schema)
+        return meta
 
 
 to_parquet = partial(dd.to_parquet, engine=GeoArrowEngine)


### PR DESCRIPTION
closes #225 

Updates method signature of the following so that they are compatible with all versions of `dask`, including `dask>=2022.12.0`:

* `dask_geopandas.io.arrow.ArrowDatasetEngine._arrow_table_to_pandas`
* `dask_geopandas.io.arrow.GeoDatasetEngine._arrow_table_to_pandas`
* `dask_geopandas.io.parquet.GeoArrowEngine._create_dd_meta`

It's been a little while since I played around with this, but I had written previously that [these lines in dask](https://github.com/dask/dask/blob/f463fcf28ff6404cc04f478b73704e35664bb5f0/dask/dataframe/io/parquet/arrow.py#L1073-L1078) are problematic, as it calls `_arrow_table_to_pandas`, where it wasn't called prior to `dask==2022.12.0`.

At the time, I thought we may need an update to `GeoDatasetEngine._arrow_table_to_pandas` to handle this, but I feel like someone with a better grasp on this library's internals may have a better idea.  Either way, it is known that this PR in its current state is an attempt to solve the problem, but it doesn't succeed entirely in doing that, as you'll see with one of the unit tests failing.