### PR TITLE
`use_nullable_dtypes` arg removed in `dask`

### DIFF
--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -19,7 +19,7 @@ import shapely.geometry
 from fsspec.core import get_fs_token_paths
 
 DASK_2022_12_0_PLUS = Version(dask.__version__) >= Version("2022.12.0")
-DASK_2023_03_2_PLUS = Version(dask.__version__) >= Version("2023.3.2")
+DASK_2023_03_2_DEV = Version(dask.__version__) > Version("2023.3.1")
 
 
 if TYPE_CHECKING:
@@ -68,6 +68,16 @@ def _get_partition_bounds(schema_metadata):
     if bbox is None or all(math.isnan(val) for val in bbox):
         return None
     return shapely.geometry.box(*bbox)
+
+
+def _extract_nullable_dtypes(**kwargs):
+    if DASK_2023_03_2_DEV:
+        use_nullable_dtypes = kwargs.get("dtype_backend", None) == "numpy_nullable"
+    elif DASK_2022_12_0_PLUS:
+        use_nullable_dtypes = kwargs.get("use_nullable_dtypes", False)
+    else:
+        use_nullable_dtypes = False
+    return use_nullable_dtypes
 
 
 class ArrowDatasetEngine:
@@ -134,8 +144,9 @@ class ArrowDatasetEngine:
 
         _kwargs = kwargs.get("arrow_to_pandas", {})
         _kwargs.update({"use_threads": False, "ignore_metadata": False})
+        use_nullable_dtypes = _extract_nullable_dtypes(**kwargs)
 
-        if DASK_2022_12_0_PLUS and kwargs.get("use_nullable_dtypes", False):
+        if use_nullable_dtypes:
             from dask.dataframe.io.parquet.arrow import PYARROW_NULLABLE_DTYPE_MAPPING
 
             if "types_mapper" in _kwargs:
@@ -191,8 +202,9 @@ class GeoDatasetEngine:
 
         _kwargs = kwargs.get("arrow_to_pandas", {})
         _kwargs.update({"use_threads": False, "ignore_metadata": False})
+        use_nullable_dtypes = _extract_nullable_dtypes(**kwargs)
 
-        if DASK_2022_12_0_PLUS and kwargs.get("use_nullable_dtypes", False):
+        if use_nullable_dtypes:
             from dask.dataframe.io.parquet.arrow import PYARROW_NULLABLE_DTYPE_MAPPING
 
             if "types_mapper" in _kwargs:

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -19,6 +19,7 @@ import shapely.geometry
 from fsspec.core import get_fs_token_paths
 
 DASK_2022_12_0_PLUS = Version(dask.__version__) >= Version("2022.12.0")
+DASK_2023_03_2_PLUS = Version(dask.__version__) >= Version("2023.3.2")
 
 
 if TYPE_CHECKING:

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -19,7 +19,7 @@ import shapely.geometry
 from fsspec.core import get_fs_token_paths
 
 DASK_2022_12_0_PLUS = Version(dask.__version__) >= Version("2022.12.0")
-DASK_2023_03_2_DEV = Version(dask.__version__) > Version("2023.3.1")
+DASK_2023_04_0 = Version(dask.__version__) >= Version("2023.4.0")
 
 
 if TYPE_CHECKING:
@@ -71,7 +71,7 @@ def _get_partition_bounds(schema_metadata):
 
 
 def _extract_nullable_dtypes(**kwargs):
-    if DASK_2023_03_2_DEV:
+    if DASK_2023_04_0:
         use_nullable_dtypes = kwargs.get("dtype_backend", None) == "numpy_nullable"
     elif DASK_2022_12_0_PLUS:
         use_nullable_dtypes = kwargs.get("use_nullable_dtypes", False)

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -6,6 +6,7 @@ import dask.dataframe as dd
 
 from .arrow import (
     DASK_2022_12_0_PLUS,
+    DASK_2023_03_2_PLUS,
     GeoDatasetEngine,
     _get_partition_bounds,
     _update_meta_to_geodataframe,
@@ -87,7 +88,7 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     @classmethod
     def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
         """Overriding private method for dask >= 2021.10.0"""
-        if DASK_2022_12_0_PLUS:
+        if DASK_2022_12_0_PLUS and not DASK_2023_03_2_PLUS:
             meta = super()._create_dd_meta(dataset_info, use_nullable_dtypes)
         else:
             meta = super()._create_dd_meta(dataset_info)

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -6,7 +6,7 @@ import dask.dataframe as dd
 
 from .arrow import (
     DASK_2022_12_0_PLUS,
-    DASK_2023_03_2_DEV,
+    DASK_2023_04_0,
     GeoDatasetEngine,
     _get_partition_bounds,
     _update_meta_to_geodataframe,
@@ -88,7 +88,7 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     @classmethod
     def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
         """Overriding private method for dask >= 2021.10.0"""
-        if DASK_2022_12_0_PLUS and not DASK_2023_03_2_DEV:
+        if DASK_2022_12_0_PLUS and not DASK_2023_04_0:
             meta = super()._create_dd_meta(dataset_info, use_nullable_dtypes)
         else:
             meta = super()._create_dd_meta(dataset_info)

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -6,7 +6,7 @@ import dask.dataframe as dd
 
 from .arrow import (
     DASK_2022_12_0_PLUS,
-    DASK_2023_03_2_PLUS,
+    DASK_2023_03_2_DEV,
     GeoDatasetEngine,
     _get_partition_bounds,
     _update_meta_to_geodataframe,
@@ -88,7 +88,7 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
     @classmethod
     def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
         """Overriding private method for dask >= 2021.10.0"""
-        if DASK_2022_12_0_PLUS and not DASK_2023_03_2_PLUS:
+        if DASK_2022_12_0_PLUS and not DASK_2023_03_2_DEV:
             meta = super()._create_dd_meta(dataset_info, use_nullable_dtypes)
         else:
             meta = super()._create_dd_meta(dataset_info)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/10076, `use_nullable_dtypes` will be removed from `_create_dd_meta` signature. Making a corresponding change here.