### PR TITLE
typo fix

### DIFF
--- a/doc/source/getting_started.md
+++ b/doc/source/getting_started.md
@@ -47,7 +47,7 @@ import dask_geopandas
 ddf = dd.read_csv('...')
 
 ddf = ddf.set_geometry(
-    dask_geopandas.points_from_xy(ddf, 'latitude', 'longitude')
+    dask_geopandas.points_from_xy(ddf, 'longitude', 'latitude')
 )
 ```
 


### PR DESCRIPTION
Order for the `points_from_xy` example was wrong. `points_from_xy` expects lon-lat, not lat-lon.

I ran was stuck on this for a bit until I realized what's going on😅