### PR TITLE
DOC: Pin pydata-sphinx-theme in docs requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,9 @@
 geopandas>=0.10
 numpydoc==1.1.0
 sphinx-book-theme
+# sphinx-book-theme is incompatible with pydata-sphinx-theme>0.13.2
+# https://github.com/executablebooks/sphinx-book-theme/issues/711
+pydata-sphinx-theme==0.13.2
 myst-nb
 myst-parser
 sphinx_copybutton

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,7 @@
 geopandas>=0.10
 numpydoc==1.1.0
 sphinx-book-theme
-# sphinx-book-theme is incompatible with pydata-sphinx-theme>0.13.2
-# https://github.com/executablebooks/sphinx-book-theme/issues/711
-pydata-sphinx-theme==0.13.2
+pydata-sphinx-theme
 myst-nb
 myst-parser
 sphinx_copybutton


### PR DESCRIPTION
https://github.com/executablebooks/sphinx-book-theme/issues/711 is the upstream issue in sphinx-book-theme to fix the error at https://readthedocs.org/projects/dask-geopandas/builds/19962281/.

This pins pydata-sphinx-theme temporarily.