### PR TITLE
[compat]: Fixed test for pandas>2

### DIFF
--- a/continuous_integration/envs/310-latest.yaml
+++ b/continuous_integration/envs/310-latest.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.10
-  - dask=2022.10.0
+  - dask
   - distributed
   - geopandas
   - pygeos

--- a/continuous_integration/envs/38-minimal.yaml
+++ b/continuous_integration/envs/38-minimal.yaml
@@ -6,8 +6,9 @@ dependencies:
   - python=3.8
   - numpy=1.20
   - dask=2021.06.0
-  - distributed
+  - distributed=2021.06.0
   - geopandas=0.10
+  - pandas=1.5.3
   - pygeos
   - pyproj=2.6
   - packaging

--- a/continuous_integration/envs/39-no-optional-deps.yaml
+++ b/continuous_integration/envs/39-no-optional-deps.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # required dependencies
   - python=3.9
-  - dask=2022.6.0
+  - dask
   - distributed
   - geopandas
   - pygeos

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -25,6 +25,7 @@ import dask_geopandas
 
 DASK_2022_8_1 = Version(dask.__version__) >= Version("2022.8.1")
 GEOPANDAS_0_12 = Version(geopandas.__version__) >= Version("0.12.0")
+PANDAS_2_0_0 = Version(pd.__version__) >= Version("2.0.0")
 
 
 if Version(shapely.__version__) < Version("2.0"):

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -15,6 +15,7 @@ from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from dask_geopandas.hilbert_distance import _hilbert_distance
 from dask_geopandas.morton_distance import _morton_distance
 from dask_geopandas.geohash import _geohash
+from dask_geopandas.core import PANDAS_2_0_0
 
 
 @pytest.fixture
@@ -640,8 +641,12 @@ class TestDissolve:
         gpd_sum = self.world.dissolve("continent", aggfunc="sum")
         dd_sum = self.ddf.dissolve("continent", aggfunc="sum").compute()
         # drop due to https://github.com/geopandas/geopandas/issues/1999
+        if not PANDAS_2_0_0:
+            drop = ["name", "iso_a3"]
+        else:
+            drop = []
         assert_geodataframe_equal(
-            gpd_sum, dd_sum.drop(columns=["name", "iso_a3"]), check_like=True
+            gpd_sum, dd_sum.drop(columns=drop), check_like=True
         )
 
     @pytest.mark.skipif(

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -645,9 +645,7 @@ class TestDissolve:
             drop = ["name", "iso_a3"]
         else:
             drop = []
-        assert_geodataframe_equal(
-            gpd_sum, dd_sum.drop(columns=drop), check_like=True
-        )
+        assert_geodataframe_equal(gpd_sum, dd_sum.drop(columns=drop), check_like=True)
 
     @pytest.mark.skipif(
         Version(dask.__version__) == Version("2022.01.1"),

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ import versioneer
 
 install_requires = [
     "geopandas>=0.10",
-    "dask>=2021.06.0",
-    "distributed>=2021.06.0",
+    "dask>=2023.2.0",
+    "distributed>=2023.2.0",
     "packaging",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ import versioneer
 
 install_requires = [
     "geopandas>=0.10",
-    "dask>=2023.2.0",
-    "distributed>=2023.2.0",
+    "dask>=2021.06.0",
+    "distributed>=2021.06.0",
     "packaging",
 ]
 


### PR DESCRIPTION
pandas 2.0 changed a behavior w.r.t. groupby and non-numeric columns. This test doesn't need to drop the columns anymore. xref https://github.com/geopandas/geopandas/issues/1999