### PR TITLE
Add missing dependency in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 flake8
 hilbertcurve
+pygeohash
 pymorton
 pytest


### PR DESCRIPTION
Hi i cloned the repo and tried running the following to run the tests
```
pip install -e .
pip install -r requirements-dev.txt 
```

but when i was running the test i hit the following error
```
❯ pytest dask_geopandas/tests
ERROR collecting dask_geopandas/tests/test_geohash.py _______________________________________________________________________________
ImportError while importing test module '/Users/jtmiclat/personal/dask-geopandas/dask_geopandas/tests/test_geohash.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../.pyenv/versions/3.9.16/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
dask_geopandas/tests/test_geohash.py:6: in <module>
    from pygeohash import encode
E   ModuleNotFoundError: No module named 'pygeohash' 
```

Baed on https://github.com/geopandas/dask-geopandas/blob/d3e15d1efb5a9a6c74a13f933ea2d84196992fac/continuous_integration/envs/39-no-optional-deps.yaml#L13-L20 

requirements-dev.txt  was missing pygeohash. After adding it to the requirments-dev.txt the test ran correctly