### PR TITLE
TST: skip tests that need pygeohash/hilbertcurve/pymorton if not installed

### DIFF
--- a/continuous_integration/envs/39-no-optional-deps.yaml
+++ b/continuous_integration/envs/39-no-optional-deps.yaml
@@ -13,8 +13,3 @@ dependencies:
   # test dependencies
   - pytest
   - pytest-cov
-  - hilbertcurve
-  - pygeohash
-  - pip
-  - pip:
-      - pymorton

--- a/dask_geopandas/tests/test_geohash.py
+++ b/dask_geopandas/tests/test_geohash.py
@@ -3,7 +3,6 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
 from pandas.testing import assert_index_equal
-from pygeohash import encode
 from dask_geopandas.geohash import _calculate_mid_points
 from dask_geopandas import from_geopandas
 import geopandas
@@ -37,13 +36,14 @@ def geoseries_polygons():
 
 
 def geohash_dask(geoseries):
+    pygeohash = pytest.importorskip("pygeohash")
 
     p = 12
     as_string = True
     bounds = geoseries.bounds.to_numpy()
     x_mids, y_mids = _calculate_mid_points(bounds)
 
-    geohash_vec = np.vectorize(encode)
+    geohash_vec = np.vectorize(pygeohash.encode)
     # Encode mid points of geometries using geohash
     expected = geohash_vec(y_mids, x_mids, p)
 

--- a/dask_geopandas/tests/test_hilbert_distance.py
+++ b/dask_geopandas/tests/test_hilbert_distance.py
@@ -3,7 +3,6 @@ import pandas as pd
 import numpy as np
 
 from pandas.testing import assert_index_equal, assert_series_equal
-from hilbertcurve.hilbertcurve import HilbertCurve
 from dask_geopandas.hilbert_distance import (
     _hilbert_distance,
     _continuous_to_discrete_coords,
@@ -60,6 +59,8 @@ def geoseries_polygons():
 
 
 def hilbert_distance_dask(geoseries, level=16):
+    pytest.importorksip("hilbertcurve")
+    from hilbertcurve.hilbertcurve import HilbertCurve
 
     bounds = geoseries.bounds.to_numpy()
     total_bounds = geoseries.total_bounds

--- a/dask_geopandas/tests/test_hilbert_distance.py
+++ b/dask_geopandas/tests/test_hilbert_distance.py
@@ -59,7 +59,7 @@ def geoseries_polygons():
 
 
 def hilbert_distance_dask(geoseries, level=16):
-    pytest.importorksip("hilbertcurve")
+    pytest.importorskip("hilbertcurve")
     from hilbertcurve.hilbertcurve import HilbertCurve
 
     bounds = geoseries.bounds.to_numpy()

--- a/dask_geopandas/tests/test_morton_distance.py
+++ b/dask_geopandas/tests/test_morton_distance.py
@@ -1,7 +1,6 @@
 import pytest
 import pandas as pd
 from pandas.testing import assert_index_equal, assert_series_equal
-from pymorton import interleave  # https://github.com/trevorprater/pymorton
 from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
 from dask_geopandas import from_geopandas
 import geopandas
@@ -35,6 +34,8 @@ def geoseries_polygons():
 
 
 def morton_distance_dask(geoseries):
+    # https://github.com/trevorprater/pymorton
+    pymorton = pytest.importorskip("pymorton")
 
     bounds = geoseries.bounds.to_numpy()
     total_bounds = geoseries.total_bounds
@@ -50,7 +51,7 @@ def morton_distance_dask(geoseries):
     for i in range(len(x_coords)):
         x = int(x_coords[i])
         y = int(y_coords[i])
-        expected.append(interleave(x, y))
+        expected.append(pymorton.interleave(x, y))
 
     assert list(result) == expected
     assert isinstance(result, pd.Series)


### PR DESCRIPTION
Given those are optional test dependencies and only used in a few tests, I think it's nice to skip those when you don't have them installed locally.