### PR TITLE
TST: disable dask dataframe.convert-strings (pyarrow strings) for now

### DIFF
--- a/dask_geopandas/tests/conftest.py
+++ b/dask_geopandas/tests/conftest.py
@@ -1,0 +1,6 @@
+import dask
+
+
+# TODO Disable usage of pyarrow strings until the expected results in the tests
+# are updated to use those as well
+dask.config.set({"dataframe.convert-string": False})


### PR DESCRIPTION
Currently there are lots of failures like

```
AssertionError: Attributes of GeoDataFrame.iloc[:, 0] (column name="name_left") are different

Attribute "dtype" are different
[left]:  object
[right]: string[pyarrow]
```

We will have to update our tests (or the assert equal method) to deal with this dtypes difference, but for now disabling this option to get the tests green again.