### PR TITLE
TST/CI: pin moto<5 to fix timeout

### DIFF
--- a/continuous_integration/envs/310-latest.yaml
+++ b/continuous_integration/envs/310-latest.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-cov
   - hilbertcurve
   - s3fs
-  - moto
+  - moto<5  # <5 pin because of https://github.com/dask/dask/issues/10869
   - flask # needed for moto server
   # optional dependencies
   - pyarrow

--- a/continuous_integration/envs/311-dev.yaml
+++ b/continuous_integration/envs/311-dev.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-cov
   - hilbertcurve
   - s3fs
-  - moto
+  - moto<5  # <5 pin because of https://github.com/dask/dask/issues/10869
   - flask # needed for moto server
   # optional dependencies
   - pyarrow

--- a/continuous_integration/envs/311-latest.yaml
+++ b/continuous_integration/envs/311-latest.yaml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-cov
   - hilbertcurve
   - s3fs
-  - moto
+  - moto<5  # <5 pin because of https://github.com/dask/dask/issues/10869
   - flask # needed for moto server
   # optional dependencies
   - pyarrow


### PR DESCRIPTION
We are seeing timeouts with the latest moto, similarly as in dask itself: https://github.com/dask/dask/issues/10869. Therefore pinning to <5 for now.