### PR TITLE
CI/RLS: update minimum supported versions (Python 3.9, geopandas 0.12, dask 2022.06)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,9 @@ jobs:
           - env: ci/envs/312-dev.yaml
             os: ubuntu-latest
 
+    env:
+      DASK_DATAFRAME__QUERY_PLANNING: False
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,17 +29,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         env:
-          - ci/envs/39-no-optional-deps.yaml
-          - ci/envs/38-minimal.yaml
-          - ci/envs/310-latest.yaml
+          - ci/envs/310-no-optional-deps.yaml
+          - ci/envs/39-minimal.yaml
           - ci/envs/311-latest.yaml
+          - ci/envs/312-latest.yaml
 
         include:
-          - env: ci/envs/310-latest.yaml
+          - env: ci/envs/311-latest.yaml
             os: macos-latest
-          - env: ci/envs/310-latest.yaml
+          - env: ci/envs/311-latest.yaml
             os: windows-latest
-          - env: ci/envs/311-dev.yaml
+          - env: ci/envs/312-dev.yaml
             os: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.4.0 (March ??, 2024)
+------------------------------
+
+Updated minimum supported versions of dependencies, now requiring Python 3.9,
+GeoPandas 0.12, numpy 1.23 and dask/distributed 2022.06.0.
+
 Version 0.3.1 (April 28, 2023)
 ------------------------------
 

--- a/ci/envs/310-no-optional-deps.yaml
+++ b/ci/envs/310-no-optional-deps.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
-  - python=3.9
+  - python=3.10
   - dask
   - distributed
   - geopandas

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -7,9 +7,8 @@ dependencies:
   - dask
   - distributed
   - geopandas
-  - shapely >= 2
   - pygeos
-  - pyproj
+  - pyproj=3.3
   - packaging
   # test dependencies
   - pytest
@@ -20,7 +19,7 @@ dependencies:
   - flask # needed for moto server
   # optional dependencies
   - pyarrow
-  - pyogrio
+  - pyogrio>=0.4
   - pygeohash
   - pip
   - pip:

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -8,7 +8,7 @@ dependencies:
   - distributed
   - geopandas
   - pygeos
-  - pyproj=3.3
+  - pyproj=3.4
   - packaging
   # test dependencies
   - pytest

--- a/ci/envs/312-dev.yaml
+++ b/ci/envs/312-dev.yaml
@@ -3,12 +3,13 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
-  - python=3.10
-  - dask
+  - python=3.12
   - distributed
-  - geopandas
-  - pygeos
-  - pyproj=3.3
+  - pandas
+  - shapely
+  - fiona
+  - pyproj
+  - fsspec
   - packaging
   # test dependencies
   - pytest
@@ -19,8 +20,11 @@ dependencies:
   - flask # needed for moto server
   # optional dependencies
   - pyarrow
-  - pyogrio>=0.4
+  - pyogrio
   - pygeohash
   - pip
   - pip:
       - pymorton
+      - git+https://github.com/geopandas/geopandas.git@main
+      - git+https://github.com/pygeos/pygeos.git@master
+      - git+https://github.com/dask/dask.git@main

--- a/ci/envs/312-dev.yaml
+++ b/ci/envs/312-dev.yaml
@@ -26,5 +26,5 @@ dependencies:
   - pip:
       - pymorton
       - git+https://github.com/geopandas/geopandas.git@main
-      - git+https://github.com/pygeos/pygeos.git@master
+      - git+https://github.com/shapely/shapely.git@main
       - git+https://github.com/dask/dask.git@main

--- a/ci/envs/312-latest.yaml
+++ b/ci/envs/312-latest.yaml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
-  - python=3.11
+  - python=3.12
+  - dask
   - distributed
-  - pandas
-  - shapely
-  - fiona
+  - geopandas
+  - shapely >= 2
+  - pygeos
   - pyproj
-  - fsspec
   - packaging
   # test dependencies
   - pytest
@@ -25,6 +25,3 @@ dependencies:
   - pip
   - pip:
       - pymorton
-      - git+https://github.com/geopandas/geopandas.git@main
-      - git+https://github.com/pygeos/pygeos.git@master
-      - git+https://github.com/dask/dask.git@main

--- a/ci/envs/312-latest.yaml
+++ b/ci/envs/312-latest.yaml
@@ -8,7 +8,6 @@ dependencies:
   - distributed
   - geopandas
   - shapely >= 2
-  - pygeos
   - pyproj
   - packaging
   # test dependencies

--- a/ci/envs/39-minimal.yaml
+++ b/ci/envs/39-minimal.yaml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
 dependencies:
   # required dependencies
-  - python=3.8
-  - numpy=1.20
-  - dask=2021.06.0
-  - distributed=2021.06.0
-  - geopandas=0.10
+  - python=3.9
+  - numpy=1.23
+  - dask=2022.06.0
+  - distributed=2022.06.0
+  - geopandas=0.12
   - pandas=1.5.3
   - pygeos
-  - pyproj=2.6
+  - pyproj=3.0
   - packaging
   # test dependencies
   - pytest

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -77,15 +77,6 @@ class GeoArrowEngine(GeoDatasetEngine, DaskArrowDatasetEngine):
         return _update_meta_to_geodataframe(meta, schema.metadata)
 
     @classmethod
-    def _generate_dd_meta(cls, schema, index, categories, partition_info):
-        """Overriding private method for dask < 2021.10.0"""
-        meta, index_cols, categories, index, partition_info = super()._generate_dd_meta(
-            schema, index, categories, partition_info
-        )
-        meta = cls._update_meta(meta, schema)
-        return meta, index_cols, categories, index, partition_info
-
-    @classmethod
     def _create_dd_meta(cls, dataset_info, use_nullable_dtypes=False):
         """Overriding private method for dask >= 2021.10.0"""
         if DASK_2022_12_0_PLUS and not DASK_2023_04_0:

--- a/dask_geopandas/tests/io/test_parquet.py
+++ b/dask_geopandas/tests/io/test_parquet.py
@@ -1,8 +1,5 @@
-from packaging.version import Version
-
 import geopandas
 import dask_geopandas
-import dask
 import dask.dataframe as dd
 
 import pytest
@@ -161,10 +158,6 @@ def test_parquet_empty_partitions(tmp_path, naturalearth_lowres):
     assert result.spatial_partitions is None
 
 
-@pytest.mark.skipif(
-    not Version(dask.__version__) >= Version("2022.06.0"),
-    reason="Only works with dask 2022.06.0 or up",
-)
 def test_parquet_partitions_with_all_missing_strings(tmp_path):
     df = geopandas.GeoDataFrame(
         {"col": ["a", "b", None, None]},
@@ -180,10 +173,6 @@ def test_parquet_partitions_with_all_missing_strings(tmp_path):
     assert_geodataframe_equal(result.compute(), df)
 
 
-@pytest.mark.skipif(
-    Version(dask.__version__) < Version("2021.10.0"),
-    reason="Only correct error message with dask 2021.10.0 or up",
-)
 def test_parquet_empty_dataset(tmp_path):
     # ensure informative error message if there are no parts (otherwise
     # will raise in not finding any geo metadata)
@@ -191,10 +180,6 @@ def test_parquet_empty_dataset(tmp_path):
         dask_geopandas.read_parquet(tmp_path / "data.*.parquet")
 
 
-@pytest.mark.skipif(
-    not Version(dask.__version__) > Version("2022.02.0"),
-    reason="Only works with dask 2022.02.1 or up",
-)
 @pytest.mark.parametrize("write_metadata_file", [True, False])
 def test_parquet_partition_on(tmp_path, naturalearth_lowres, write_metadata_file):
     df = geopandas.read_file(naturalearth_lowres)

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -644,20 +644,12 @@ class TestDissolve:
             drop = []
         assert_geodataframe_equal(gpd_sum, dd_sum.drop(columns=drop), check_like=True)
 
-    @pytest.mark.skipif(
-        Version(dask.__version__) == Version("2022.01.1"),
-        reason="Regression in dask 2022.01.1 https://github.com/dask/dask/issues/8611",
-    )
     def test_split_out(self):
         gpd_default = self.world.dissolve("continent")
         dd_split = self.ddf.dissolve("continent", split_out=4)
         assert dd_split.npartitions == 4
         assert_geodataframe_equal(gpd_default, dd_split.compute(), check_like=True)
 
-    @pytest.mark.skipif(
-        Version(dask.__version__) == Version("2022.01.1"),
-        reason="Regression in dask 2022.01.1 https://github.com/dask/dask/issues/8611",
-    )
     @pytest.mark.xfail
     def test_split_out_name(self):
         gpd_default = self.world.rename_geometry("geom").dissolve("continent")
@@ -758,10 +750,6 @@ class TestSpatialShuffle:
 
         assert_geodataframe_equal(ddf.compute(), expected)
 
-    @pytest.mark.skipif(
-        Version(dask.__version__) <= Version("2021.03.0"),
-        reason="older Dask has a bug in sorting",
-    )
     @pytest.mark.parametrize(
         "calculate_partitions,npartitions",
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: System :: Distributed Computing",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "geopandas>=0.10",
-    "dask>=2021.06.0",
-    "distributed>=2021.06.0",
+    "geopandas>=0.12",
+    "dask>=2022.06.0",
+    "distributed>=2022.06.0",
     "packaging",
 ]
 


### PR DESCRIPTION
Updating minimum required versions and CI:

- Python 3.8 -> 3.9
- GeoPandas 0.10 -> 0.12
- dask/distributed 2021.06 -> 2022.06

and in addition also bumped the minimum tested versions for numpy 1.20 -> 1.23 and pyproj 2.6 -> 3.0