### PR TITLE
MAINT: update linting setup (align with geopandas, use ruff, move config to pyproject.toml)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,18 @@
+ci:
+    autofix_prs: false
+    autoupdate_schedule: weekly
+
 files: 'dask_geopandas\/'
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        language_version: python3
+    - repo: https://github.com/psf/black
+      rev: 24.2.0
+      hooks:
+          - id: black
+            language_version: python3
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: "v0.4.4"
+      hooks:
+        - id: ruff
+          name: sort imports with ruff
+          args: [--select, I, --fix]
+        - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
     autofix_prs: false
-    autoupdate_schedule: weekly
+    autoupdate_schedule: quarterly
 
 files: 'dask_geopandas\/'
 repos:

--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -3,7 +3,6 @@ from packaging.version import Version
 
 from dask import config
 
-
 # Check if dask-dataframe is using dask-expr (default of None means True as well)
 QUERY_PLANNING_ON = config.get("dataframe.query-planning", False)
 if QUERY_PLANNING_ON is None:
@@ -15,20 +14,19 @@ if QUERY_PLANNING_ON is None:
         QUERY_PLANNING_ON = True
 
 
-from dask.dataframe.core import get_parallel_type
-from dask.dataframe.utils import meta_nonempty
-from dask.dataframe.extensions import make_array_nonempty, make_scalar
 from dask.base import normalize_token
-from dask.dataframe.dispatch import make_meta_dispatch, pyarrow_schema_dispatch
 from dask.dataframe.backends import _nonempty_index, meta_nonempty_dataframe
+from dask.dataframe.core import get_parallel_type
+from dask.dataframe.dispatch import make_meta_dispatch, pyarrow_schema_dispatch
+from dask.dataframe.extensions import make_array_nonempty, make_scalar
+from dask.dataframe.utils import meta_nonempty
 
-import shapely.geometry
-from shapely.geometry.base import BaseGeometry
 import geopandas
+import shapely.geometry
 from geopandas.array import GeometryArray, GeometryDtype, from_shapely
+from shapely.geometry.base import BaseGeometry
 
-from .core import GeoSeries, GeoDataFrame
-
+from .core import GeoDataFrame, GeoSeries
 
 get_parallel_type.register(geopandas.GeoDataFrame, lambda _: GeoDataFrame)
 get_parallel_type.register(geopandas.GeoSeries, lambda _: GeoSeries)
@@ -79,8 +77,8 @@ def tokenize_geometryarray(x):
 
 @pyarrow_schema_dispatch.register((geopandas.GeoDataFrame,))
 def get_pyarrow_schema_geopandas(obj):
-    import pyarrow as pa
     import pandas as pd
+    import pyarrow as pa
 
     df = pd.DataFrame(obj.copy())
     for col in obj.columns[obj.dtypes == "geometry"]:

--- a/dask_geopandas/clip.py
+++ b/dask_geopandas/clip.py
@@ -1,9 +1,10 @@
 import numpy as np
-import geopandas
 
+from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import derived_from
-from dask.base import tokenize
+
+import geopandas
 
 from . import backends
 
@@ -39,8 +40,8 @@ def clip(gdf, mask, keep_geom_type=False):
 
     name = f"clip-{tokenize(gdf, mask, keep_geom_type)}"
     dsk = {
-        (name, i): (geopandas.clip, (gdf._name, l), mask, keep_geom_type)
-        for i, l in enumerate(intersecting_partitions)
+        (name, i): (geopandas.clip, (gdf._name, part), mask, keep_geom_type)
+        for i, part in enumerate(intersecting_partitions)
     }
     divisions = [None] * (len(dsk) + 1)
     graph = HighLevelGraph.from_collections(name, dsk, dependencies=[gdf])

--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -1,29 +1,27 @@
 import warnings
-
 from packaging.version import Version
 
 import numpy as np
 import pandas as pd
 
 import dask
-import dask.dataframe as dd
 import dask.array as da
-from dask.dataframe.core import _emulate, map_partitions, elemwise, new_dd_object
+import dask.dataframe as dd
+from dask.base import tokenize
+from dask.dataframe.core import _emulate, elemwise, map_partitions, new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M, OperatorMethodMixin, derived_from, ignore_warning
-from dask.base import tokenize
 
 import geopandas
 import shapely
-from shapely.geometry.base import BaseGeometry
 from shapely.geometry import box
-
-from .hilbert_distance import _hilbert_distance
-from .morton_distance import _morton_distance
-from .geohash import _geohash
+from shapely.geometry.base import BaseGeometry
 
 import dask_geopandas
 
+from .geohash import _geohash
+from .hilbert_distance import _hilbert_distance
+from .morton_distance import _morton_distance
 
 DASK_2022_8_1 = Version(dask.__version__) >= Version("2022.8.1")
 GEOPANDAS_0_12 = Version(geopandas.__version__) >= Version("0.12.0")
@@ -155,7 +153,7 @@ class _Frame(dd.core._Frame, OperatorMethodMixin):
         def meth(self, other, *args, **kwargs):
             meta = _emulate(op, self, other)
             return map_partitions(
-                op, self, other, meta=meta, enforce_metadata=False, *args, **kwargs
+                op, self, other, *args, meta=meta, enforce_metadata=False, **kwargs
             )
 
         meth.__name__ = name

--- a/dask_geopandas/expr.py
+++ b/dask_geopandas/expr.py
@@ -1,36 +1,34 @@
-from packaging.version import Version
 import warnings
+from packaging.version import Version
 
 import numpy as np
 import pandas as pd
 
 import dask
-import dask.dataframe as dd
 import dask.array as da
+import dask.dataframe as dd
+import dask_expr as dx
+from dask.base import tokenize
 from dask.dataframe import map_partitions
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M, OperatorMethodMixin, derived_from, ignore_warning
-from dask.base import tokenize
-
-import dask_expr as dx
 from dask_expr import (
     elemwise,
     from_graph,
     get_collection_type,
 )
 from dask_expr._collection import new_collection
-from dask_expr._expr import _emulate, ApplyConcatApply
+from dask_expr._expr import ApplyConcatApply, _emulate
 
 import geopandas
 import shapely
 from shapely.geometry import box
 
-from .hilbert_distance import _hilbert_distance
-from .morton_distance import _morton_distance
-from .geohash import _geohash
-
 import dask_geopandas
 
+from .geohash import _geohash
+from .hilbert_distance import _hilbert_distance
+from .morton_distance import _morton_distance
 
 DASK_2022_8_1 = Version(dask.__version__) >= Version("2022.8.1")
 GEOPANDAS_0_12 = Version(geopandas.__version__) >= Version("0.12.0")
@@ -217,7 +215,7 @@ class _Frame(dx.FrameBase, OperatorMethodMixin):
         def meth(self, other, *args, **kwargs):
             meta = _emulate(op, self, other)
             return map_partitions(
-                op, self, other, meta=meta, enforce_metadata=False, *args, **kwargs
+                op, self, other, *args, meta=meta, enforce_metadata=False, **kwargs
             )
 
         meth.__name__ = name
@@ -301,7 +299,7 @@ class _Frame(dx.FrameBase, OperatorMethodMixin):
         graph = total_bounds.lower_completely().__dask_graph__()
         return da.Array(
             graph,
-            list(graph.keys())[0][0],
+            next(iter((graph.keys())))[0],
             chunks=((4,),),
             dtype=np.dtype("float64"),
         )

--- a/dask_geopandas/geohash.py
+++ b/dask_geopandas/geohash.py
@@ -8,6 +8,7 @@ The vectorized implementation for quantization and bit interleaving is in turn b
 "Geohash in Golang Assembly" blog (https://mmcloughlin.com/posts/geohash-assembly).
 
 """
+
 import warnings
 
 import numpy as np

--- a/dask_geopandas/hilbert_distance.py
+++ b/dask_geopandas/hilbert_distance.py
@@ -5,7 +5,6 @@ import pandas as pd
 
 
 def _hilbert_distance(gdf, total_bounds=None, level=16):
-
     """
     Calculate the distance along a Hilbert curve.
 

--- a/dask_geopandas/io/arrow.py
+++ b/dask_geopandas/io/arrow.py
@@ -4,19 +4,18 @@ import math
 from packaging.version import Version
 from typing import TYPE_CHECKING
 
-import dask
+import pandas as pd
+from fsspec.core import get_fs_token_paths
 
+import dask
 from dask.base import compute_as_if_collection, tokenize
-from dask.dataframe.core import new_dd_object, Scalar
+from dask.dataframe.core import Scalar, new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
-from dask.utils import natural_sort_key, apply
+from dask.utils import apply, natural_sort_key
 
-import pandas as pd
 import geopandas
 import shapely.geometry
-
-from fsspec.core import get_fs_token_paths
 
 from .. import backends
 
@@ -152,7 +151,8 @@ class ArrowDatasetEngine:
             from dask.dataframe.io.parquet.arrow import PYARROW_NULLABLE_DTYPE_MAPPING
 
             if "types_mapper" in _kwargs:
-                # User-provided entries take priority over PYARROW_NULLABLE_DTYPE_MAPPING
+                # User-provided entries take priority over
+                # PYARROW_NULLABLE_DTYPE_MAPPING
                 types_mapper = _kwargs["types_mapper"]
 
                 def _types_mapper(pa_type):
@@ -210,7 +210,8 @@ class GeoDatasetEngine:
             from dask.dataframe.io.parquet.arrow import PYARROW_NULLABLE_DTYPE_MAPPING
 
             if "types_mapper" in _kwargs:
-                # User-provided entries take priority over PYARROW_NULLABLE_DTYPE_MAPPING
+                # User-provided entries take priority over
+                # PYARROW_NULLABLE_DTYPE_MAPPING
                 types_mapper = _kwargs["types_mapper"]
 
                 def _types_mapper(pa_type):

--- a/dask_geopandas/io/file.py
+++ b/dask_geopandas/io/file.py
@@ -1,9 +1,10 @@
 from math import ceil
 
-from dask.base import tokenize
-from dask.highlevelgraph import HighLevelGraph
-from dask.dataframe.core import new_dd_object
 from pandas import RangeIndex
+
+from dask.base import tokenize
+from dask.dataframe.core import new_dd_object
+from dask.highlevelgraph import HighLevelGraph
 
 from .. import backends
 
@@ -83,7 +84,7 @@ def read_file(
         raise ImportError(
             "The 'read_file' function requires the 'pyogrio' package, but it is "
             "not installed or does not import correctly."
-            f"\nImporting pyogrio resulted in: {str(err)}"
+            f"\nImporting pyogrio resulted in: {err}"
         )
 
     from dask.layers import DataFrameIOLayer

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -1,8 +1,8 @@
 from functools import partial
 
-import geopandas
-
 import dask.dataframe as dd
+
+import geopandas
 
 from .. import backends
 from .arrow import (

--- a/dask_geopandas/morton_distance.py
+++ b/dask_geopandas/morton_distance.py
@@ -1,6 +1,7 @@
 import warnings
 
 import pandas as pd
+
 from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
 
 

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -1,10 +1,11 @@
 import warnings
 
 import numpy as np
-import geopandas
 
 from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
+
+import geopandas
 
 from . import backends
 
@@ -87,19 +88,19 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
 
     dsk = {}
     new_spatial_partitions = []
-    for i, (l, r) in enumerate(zip(parts_left, parts_right)):
+    for i, (part_left, part_right) in enumerate(zip(parts_left, parts_right)):
         dsk[(name, i)] = (
             geopandas.sjoin,
-            (left._name, l),
-            (right._name, r),
+            (left._name, part_left),
+            (right._name, part_right),
             how,
             predicate,
         )
         # TODO preserve spatial partitions of the output if only left has spatial
         # partitions
         if using_spatial_partitions:
-            lr = left.spatial_partitions.iloc[l]
-            rr = right.spatial_partitions.iloc[r]
+            lr = left.spatial_partitions.iloc[part_left]
+            rr = right.spatial_partitions.iloc[part_right]
             # extent = lr.intersection(rr).buffer(buffer).intersection(lr.union(rr))
             extent = lr.intersection(rr)
             new_spatial_partitions.append(extent)

--- a/dask_geopandas/tests/conftest.py
+++ b/dask_geopandas/tests/conftest.py
@@ -1,11 +1,11 @@
 import os.path
 from packaging.version import Version
 
-import pytest
-
-import geopandas
 import dask
 
+import geopandas
+
+import pytest
 
 # TODO update version once geopandas has a proper tag for 1.0
 GEOPANDAS_GE_10 = (Version(geopandas.__version__) >= Version("0.14.0+70")) and (

--- a/dask_geopandas/tests/io/conftest.py
+++ b/dask_geopandas/tests/io/conftest.py
@@ -1,10 +1,10 @@
-import os
-from contextlib import contextmanager
-import subprocess
-import shlex
 import logging
-import time
+import os
+import shlex
+import subprocess
 import sys
+import time
+from contextlib import contextmanager
 
 import pytest
 

--- a/dask_geopandas/tests/io/test_arrow.py
+++ b/dask_geopandas/tests/io/test_arrow.py
@@ -1,11 +1,12 @@
-import geopandas
-import dask_geopandas
 import dask.dataframe as dd
+
+import geopandas
+
+import dask_geopandas
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 from pandas.testing import assert_index_equal
-
 
 pa = pytest.importorskip("pyarrow")
 ds = pytest.importorskip("pyarrow.dataset")

--- a/dask_geopandas/tests/io/test_file.py
+++ b/dask_geopandas/tests/io/test_file.py
@@ -1,15 +1,17 @@
 import random
 
-import geopandas
-from shapely.geometry import Polygon
-import dask.dataframe as dd
-import dask_geopandas
 import pandas as pd
 
-import pytest
-from pandas.testing import assert_series_equal, assert_frame_equal
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+import dask.dataframe as dd
 
+import geopandas
+from shapely.geometry import Polygon
+
+import dask_geopandas
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 pytest.importorskip("pyogrio")
 

--- a/dask_geopandas/tests/io/test_parquet.py
+++ b/dask_geopandas/tests/io/test_parquet.py
@@ -1,14 +1,15 @@
 import json
 
-import geopandas
-import dask_geopandas
 import dask.dataframe as dd
+
+import geopandas
 import shapely
+
+import dask_geopandas
 
 import pytest
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_series_equal
-
 
 pa = pytest.importorskip("pyarrow")
 
@@ -227,8 +228,9 @@ def test_no_gather_spatial_partitions(tmp_path, naturalearth_lowres):
 
 def test_read_parquet_default_crs(tmp_path):
     pyproj = pytest.importorskip("pyproj")
-    from geopandas.io.arrow import _geopandas_to_arrow
     import pyarrow.parquet as pq
+
+    from geopandas.io.arrow import _geopandas_to_arrow
 
     gdf = geopandas.GeoDataFrame(geometry=[shapely.box(0, 0, 10, 10)])
     gdf["other_geom"] = gdf["geometry"].centroid

--- a/dask_geopandas/tests/test_clip.py
+++ b/dask_geopandas/tests/test_clip.py
@@ -1,8 +1,11 @@
 import geopandas
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
-import pytest
+
 import dask_geopandas
+
 from .test_core import geodf_points  # noqa: F401
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 
 def test_clip(naturalearth_lowres, naturalearth_cities):

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -1,25 +1,31 @@
 import pickle
 from packaging.version import Version
-import pytest
-import pandas as pd
+
 import numpy as np
-import geopandas
-from shapely.geometry import Polygon, Point, LineString, MultiPoint
+import pandas as pd
+
 import dask
 import dask.dataframe as dd
+
+import geopandas
+from shapely.geometry import LineString, MultiPoint, Point, Polygon
+
 import dask_geopandas
+
+import pytest
 
 if dask_geopandas.backends.QUERY_PLANNING_ON:
     from dask_expr._collection import Scalar
 else:
     from dask.dataframe.core import Scalar
 
-from pandas.testing import assert_frame_equal, assert_series_equal
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from dask_geopandas.core import GEOPANDAS_1_0, PANDAS_2_0_0
+from dask_geopandas.geohash import _geohash
 from dask_geopandas.hilbert_distance import _hilbert_distance
 from dask_geopandas.morton_distance import _morton_distance
-from dask_geopandas.geohash import _geohash
-from dask_geopandas.core import PANDAS_2_0_0, GEOPANDAS_1_0
+
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 
 @pytest.fixture

--- a/dask_geopandas/tests/test_geohash.py
+++ b/dask_geopandas/tests/test_geohash.py
@@ -1,13 +1,16 @@
-import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
 import pandas as pd
-from pandas.testing import assert_index_equal
-from dask_geopandas.geohash import _calculate_mid_points
-from dask_geopandas import from_geopandas
+
 import geopandas
-from shapely.geometry import Point, LineString, Polygon
+from shapely.geometry import LineString, Point, Polygon
 from shapely.wkt import loads
+
+from dask_geopandas import from_geopandas
+from dask_geopandas.geohash import _calculate_mid_points
+
+import pytest
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_index_equal
 
 
 @pytest.fixture

--- a/dask_geopandas/tests/test_hilbert_distance.py
+++ b/dask_geopandas/tests/test_hilbert_distance.py
@@ -1,16 +1,18 @@
-import pytest
-import pandas as pd
 import numpy as np
+import pandas as pd
 
-from pandas.testing import assert_index_equal, assert_series_equal
-from dask_geopandas.hilbert_distance import (
-    _hilbert_distance,
-    _continuous_to_discrete_coords,
-)
-from dask_geopandas import from_geopandas
 import geopandas
-from shapely.geometry import Point, LineString, Polygon
+from shapely.geometry import LineString, Point, Polygon
 from shapely.wkt import loads
+
+from dask_geopandas import from_geopandas
+from dask_geopandas.hilbert_distance import (
+    _continuous_to_discrete_coords,
+    _hilbert_distance,
+)
+
+import pytest
+from pandas.testing import assert_index_equal, assert_series_equal
 
 
 def test_hilbert_distance():

--- a/dask_geopandas/tests/test_morton_distance.py
+++ b/dask_geopandas/tests/test_morton_distance.py
@@ -1,11 +1,14 @@
-import pytest
 import pandas as pd
-from pandas.testing import assert_index_equal, assert_series_equal
-from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
-from dask_geopandas import from_geopandas
+
 import geopandas
-from shapely.geometry import Point, LineString, Polygon
+from shapely.geometry import LineString, Point, Polygon
 from shapely.wkt import loads
+
+from dask_geopandas import from_geopandas
+from dask_geopandas.hilbert_distance import _continuous_to_discrete_coords
+
+import pytest
+from pandas.testing import assert_index_equal, assert_series_equal
 
 
 @pytest.fixture

--- a/dask_geopandas/tests/test_sjoin.py
+++ b/dask_geopandas/tests/test_sjoin.py
@@ -1,9 +1,9 @@
-import pytest
-
 import geopandas
-from geopandas.testing import assert_geodataframe_equal
 
 import dask_geopandas
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal
 
 
 def test_sjoin_dask_geopandas(naturalearth_lowres, naturalearth_cities):

--- a/dask_geopandas/tests/test_spatial_partitioning.py
+++ b/dask_geopandas/tests/test_spatial_partitioning.py
@@ -1,9 +1,9 @@
-import pytest
-
 import geopandas
-from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 import dask_geopandas
+
+import pytest
+from geopandas.testing import assert_geodataframe_equal, assert_geoseries_equal
 
 
 def test_propagate_on_geometry_access(naturalearth_lowres):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,113 @@ Home = "https://geopandas.org"
 Documentation = "https://dask-geopandas.readthedocs.io/"
 Repository = "https://github.com/geopandas/dask-geopandas"
 "Issue Tracker" = "https://github.com/geopandas/dask-geopandas/issues"
+
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+extend-exclude = ["doc/*", "versioneer.py", "dask_geopandas/_version.py"]
+
+[tool.ruff.lint]
+select = [
+    # pyflakes
+    "F",
+    # pycodestyle
+    "E",
+    "W",
+    # pyupgrade
+    # "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-debugger
+    "T10",
+    # flake8-simplify
+    # "SIM",
+    # pylint
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    # misc lints
+    "PIE",
+    # implicit string concatenation
+    "ISC",
+    # type-checking imports
+    "TCH",
+    # comprehensions
+    "C4",
+    # Ruff-specific rules
+    "RUF",
+    # isort
+    "I",
+]
+
+ignore = [
+    ### Intentionally disabled
+    # module level import not at top of file
+    "E402",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # mutable-argument-default
+    "B006",
+    # unused-loop-control-variable
+    "B007",
+    # get-attr-with-constant
+    "B009",
+    # Only works with python >=3.10
+    "B905",
+    # dict literals
+    "C408",
+    # Too many arguments to function call
+    "PLR0913",
+    # Too many returns
+    "PLR0911",
+    # Too many branches
+    "PLR0912",
+    # Too many statements
+    "PLR0915",
+    # Magic number
+    "PLR2004",
+    # Redefined loop name
+    "PLW2901",
+    # Global statements are discouraged
+    "PLW0603",
+    # compare-to-empty-string
+    "PLC1901",
+
+    ### Additional checks that don't pass yet
+    # Useless statement
+    "B018",
+    # Within an except clause, raise exceptions with ...
+    "B904",
+    # Consider `elif` instead of `else` then `if` to remove indentation level
+    "PLR5501",
+    # collection-literal-concatenation
+    "RUF005",
+    # Mutable class attributes should be annotated with `typing.ClassVar`,
+    "RUF012"
+]
+
+[tool.ruff.lint.per-file-ignores]
+"dask_geopandas/__init__.py" = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+extra-standard-library = ["packaging"]
+
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "dask",
+  "geo",
+  "first-party",
+  "local-folder",
+  "testing"
+]
+
+[tool.ruff.lint.isort.sections]
+"dask" = ["dask", "dask_expr"]
+"geo" = ["geopandas", "shapely", "pyproj"]
+"testing" = ["pytest", "pandas.testing", "numpy.testing", "geopandas.tests", "geopandas.testing"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,25 +1,3 @@
-[flake8]
-exclude =
-    __init__.py,
-    versioneer.py,
-    _version.py
-ignore =
-    # Import formatting
-    E4,
-    # Space before :
-    E203,
-    # Comparing types instead of isinstance
-    E721,
-    # Assign a lambda
-    E731,
-    # Ambiguous variable names
-    E741,
-    # Allow breaks before/after binary operators
-    W503,
-    W504
-
-max-line-length = 100
-
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
Mostly just copied geopandas' setup (with its latest changes to expand the usage of ruff in https://github.com/geopandas/geopandas/pull/3291 and https://github.com/geopandas/geopandas/pull/3297), with some minor edits to adjust for dask-geopandas

The diff is mostly from sorting imports, and only few actual code changes.