### PR TITLE
Register arrow import/export dispatch to make p2p shuffle work

### DIFF
--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -1,6 +1,7 @@
 import uuid
 from packaging.version import Version
 
+import dask
 from dask import config
 
 # Check if dask-dataframe is using dask-expr (default of None means True as well)
@@ -88,8 +89,8 @@ def get_pyarrow_schema_geopandas(obj):
 
 if Version(dask.__version__) >= Version("2023.6.1"):
     from dask.dataframe.dispatch import (
-        to_pyarrow_table_dispatch,
         from_pyarrow_table_dispatch,
+        to_pyarrow_table_dispatch,
     )
 
     @to_pyarrow_table_dispatch.register((geopandas.GeoDataFrame,))

--- a/dask_geopandas/tests/test_distributed.py
+++ b/dask_geopandas/tests/test_distributed.py
@@ -12,8 +12,6 @@ distributed = pytest.importorskip("distributed")
 
 from distributed import Client, LocalCluster
 
-# from distributed.utils_test import gen_cluster
-
 
 @pytest.mark.skipif(
     Version(distributed.__version__) < Version("2024.6.0"),
@@ -38,15 +36,3 @@ def test_spatial_shuffle(naturalearth_cities):
 
     expected = df_points.sort_values("geometry").reset_index(drop=True)
     assert_geodataframe_equal(result.reset_index(drop=True), expected)
-
-
-# @gen_cluster(client=True)
-# async def test_spatial_shuffle(c, s, a, b, naturalearth_cities):
-#     df_points = geopandas.read_file(naturalearth_cities)
-#     ddf_points = dask_geopandas.from_geopandas(df_points, npartitions=4)
-
-#     ddf_result = ddf_points.spatial_shuffle(by="hilbert", calculate_partitions=False)
-#     result = (await c.compute(ddf_result)).val
-
-#     expected = df_points.sort_values("geometry").reset_index(drop=True)
-#     assert_geodataframe_equal(result.reset_index(drop=True), expected)

--- a/dask_geopandas/tests/test_distributed.py
+++ b/dask_geopandas/tests/test_distributed.py
@@ -1,16 +1,16 @@
 from packaging.version import Version
 
-import pytest
-
 import geopandas
+
 import dask_geopandas
 
+import pytest
 from geopandas.testing import assert_geodataframe_equal
 
 distributed = pytest.importorskip("distributed")
 
 
-from distributed import LocalCluster, Client
+from distributed import Client, LocalCluster
 
 # from distributed.utils_test import gen_cluster
 

--- a/dask_geopandas/tests/test_distributed.py
+++ b/dask_geopandas/tests/test_distributed.py
@@ -16,7 +16,12 @@ from distributed import LocalCluster, Client
 
 
 @pytest.mark.skipif(
-    Version(geopandas.__version__) < Version("0.13"),
+    Version(distributed.__version__) < Version("2024.6.0"),
+    reason="distributed < 2024.6 has a wrong assertion",
+    # https://github.com/dask/distributed/pull/8667
+)
+@pytest.mark.skipif(
+    Version(distributed.__version__) < Version("0.13"),
     reason="geopandas < 0.13 does not implement sorting geometries",
 )
 def test_spatial_shuffle(naturalearth_cities):

--- a/dask_geopandas/tests/test_distributed.py
+++ b/dask_geopandas/tests/test_distributed.py
@@ -1,0 +1,41 @@
+import pytest
+
+import geopandas
+import dask_geopandas
+
+from geopandas.testing import assert_geodataframe_equal
+
+distributed = pytest.importorskip("distributed")
+
+
+from distributed import LocalCluster, Client
+
+# from distributed.utils_test import gen_cluster
+
+
+def test_spatial_shuffle(naturalearth_cities):
+    df_points = geopandas.read_file(naturalearth_cities)
+
+    with LocalCluster(n_workers=1) as cluster:
+        with Client(cluster):
+            ddf_points = dask_geopandas.from_geopandas(df_points, npartitions=4)
+
+            ddf_result = ddf_points.spatial_shuffle(
+                by="hilbert", calculate_partitions=False
+            )
+            result = ddf_result.compute()
+
+    expected = df_points.sort_values("geometry").reset_index(drop=True)
+    assert_geodataframe_equal(result.reset_index(drop=True), expected)
+
+
+# @gen_cluster(client=True)
+# async def test_spatial_shuffle(c, s, a, b, naturalearth_cities):
+#     df_points = geopandas.read_file(naturalearth_cities)
+#     ddf_points = dask_geopandas.from_geopandas(df_points, npartitions=4)
+
+#     ddf_result = ddf_points.spatial_shuffle(by="hilbert", calculate_partitions=False)
+#     result = (await c.compute(ddf_result)).val
+
+#     expected = df_points.sort_values("geometry").reset_index(drop=True)
+#     assert_geodataframe_equal(result.reset_index(drop=True), expected)

--- a/dask_geopandas/tests/test_distributed.py
+++ b/dask_geopandas/tests/test_distributed.py
@@ -1,3 +1,5 @@
+from packaging.version import Version
+
 import pytest
 
 import geopandas
@@ -13,6 +15,10 @@ from distributed import LocalCluster, Client
 # from distributed.utils_test import gen_cluster
 
 
+@pytest.mark.skipif(
+    Version(geopandas.__version__) < Version("0.13"),
+    reason="geopandas < 0.13 does not implement sorting geometries",
+)
 def test_spatial_shuffle(naturalearth_cities):
     df_points = geopandas.read_file(naturalearth_cities)
 


### PR DESCRIPTION
This registers our own implementation for pyarrow table <-> (Geo)DataFrame conversion through the dispatch mechanism. The distributed p2p shuffle algorithm uses that under the hood (it converts to pyarrow to send the data to other workers), and so with this change (and with the latest distributed release, as we require the fix from https://github.com/dask/distributed/pull/8667), a distributed `spatial_shuffle()` now works.