### PR TITLE
DOC: fix indentation in docstring of from_wkb/from_wkt

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -891,10 +891,10 @@ def from_wkt(wkt, crs=None):
     wkt: dask Series
         A dask Series containing WKT objects.
     crs: value, optional
-            Coordinate Reference System of the geometry objects. Can be anything
-            accepted by
-            :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
-            such as an authority string (eg "EPSG:4326") or a WKT string.
+        Coordinate Reference System of the geometry objects.
+        Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
 
     Returns
     -------
@@ -916,10 +916,10 @@ def from_wkb(wkb, crs=None):
     wkb: dask Series
         A dask Series containing WKB objects.
     crs: value, optional
-            Coordinate Reference System of the geometry objects. Can be anything
-            accepted by
-            :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
-            such as an authority string (eg "EPSG:4326") or a WKT string.
+        Coordinate Reference System of the geometry objects.
+        Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
 
     Returns
     -------

--- a/dask_geopandas/expr.py
+++ b/dask_geopandas/expr.py
@@ -923,10 +923,10 @@ def from_wkt(wkt, crs=None):
     wkt: dask Series
         A dask Series containing WKT objects.
     crs: value, optional
-            Coordinate Reference System of the geometry objects. Can be anything
-            accepted by
-            :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
-            such as an authority string (eg "EPSG:4326") or a WKT string.
+        Coordinate Reference System of the geometry objects.
+        Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
 
     Returns
     -------
@@ -948,10 +948,10 @@ def from_wkb(wkb, crs=None):
     wkb: dask Series
         A dask Series containing WKB objects.
     crs: value, optional
-            Coordinate Reference System of the geometry objects. Can be anything
-            accepted by
-            :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
-            such as an authority string (eg "EPSG:4326") or a WKT string.
+        Coordinate Reference System of the geometry objects.
+        Can be anything accepted by
+        :meth:`pyproj.CRS.from_user_input() <pyproj.crs.CRS.from_user_input>`,
+        such as an authority string (eg "EPSG:4326") or a WKT string.
 
     Returns
     -------


### PR DESCRIPTION
Small follow-up on https://github.com/geopandas/dask-geopandas/pull/293 fixing some whitespace issue in the docstrings