### PR TITLE
Allow to use latest dask without dask-expr

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           - ci/envs/39-minimal.yaml
           - ci/envs/311-no-expr.yaml
           - ci/envs/311-latest.yaml
+          - ci/envs/311-latest-no-expr.yaml
           - ci/envs/312-latest.yaml
 
         include:

--- a/ci/envs/311-latest-no-expr.yaml
+++ b/ci/envs/311-latest-no-expr.yaml
@@ -1,0 +1,24 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python=3.11
+  - dask-core
+  - geopandas
+  - pyproj=3.4
+  - packaging
+  # test dependencies
+  - pytest
+  - pytest-cov
+  - hilbertcurve
+  - s3fs
+  - moto<5  # <5 pin because of https://github.com/dask/dask/issues/10869
+  - flask # needed for moto server
+  # optional dependencies
+  - pyarrow
+  - pyogrio>=0.4
+  - pygeohash
+  - pip
+  - pip:
+      - pymorton

--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -1,18 +1,25 @@
 import uuid
 from packaging.version import Version
 
+import pandas as pd
+
 import dask
 from dask import config
 
-# Check if dask-dataframe is using dask-expr (default of None means True as well)
-QUERY_PLANNING_ON = config.get("dataframe.query-planning", False)
+# Check if dask-dataframe is using dask-expr (mimix the logic of dask.dataframe
+# _dask_expr_enabled() - default of None means True as well if dask-expr is available)
+QUERY_PLANNING_ON = config.get("dataframe.query-planning")
 if QUERY_PLANNING_ON is None:
-    import pandas as pd
-
     if Version(pd.__version__).major < 2:
         QUERY_PLANNING_ON = False
     else:
-        QUERY_PLANNING_ON = True
+        try:
+            import dask_expr  # noqa: F401
+        except ImportError:
+            # dask will raise error or warning depending on the config
+            QUERY_PLANNING_ON = False
+        else:
+            QUERY_PLANNING_ON = True
 
 
 from dask.base import normalize_token

--- a/dask_geopandas/backends.py
+++ b/dask_geopandas/backends.py
@@ -8,7 +8,7 @@ from dask import config
 
 # Check if dask-dataframe is using dask-expr (mimix the logic of dask.dataframe
 # _dask_expr_enabled() - default of None means True as well if dask-expr is available)
-QUERY_PLANNING_ON = config.get("dataframe.query-planning")
+QUERY_PLANNING_ON = config.get("dataframe.query-planning", False)
 if QUERY_PLANNING_ON is None:
     if Version(pd.__version__).major < 2:
         QUERY_PLANNING_ON = False


### PR DESCRIPTION
From https://github.com/conda-forge/dask-geopandas-feedstock/pull/17. For the default of `QUERY_PLANNING_ON` of `None`, we were always setting it to True (for recent pandas), while upstream dask still sets it to False (with warning) if `dask-expr` is not installed. 
So updating our logic here to mimic what dask does, also still allowing to use dask-geopandas without dask-expr with recent dask (although dask will still give a noisy warning in that case about installing dask-expr)