### PR TITLE
RLS - packaging: depend on dask[dataframe] to automatically get dask-expr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.9"
 dependencies = [
     "geopandas>=0.12",
     "shapely>=2.0",
-    "dask>=2022.06.0",
+    "dask[dataframe]>=2022.06.0",
     "distributed>=2022.06.0",
     "packaging",
 ]


### PR DESCRIPTION
See discussion in https://github.com/conda-forge/dask-geopandas-feedstock/pull/17. 

While in theory it is still possible to use recent dask without dask-expr, dask will raise warning about it (by default, you can still silence the warning as well by setting `"dataframe.query-planning"` config to False), it's probably easier for our users to automatically get it installed.