### PR TITLE
fix missing crs in metadata for points_from_xy

### DIFF
--- a/dask_geopandas/core.py
+++ b/dask_geopandas/core.py
@@ -878,7 +878,7 @@ def points_from_xy(df, x="x", y="y", z="z", crs=None):
         )
 
     return df.map_partitions(
-        func, x, y, z, meta=geopandas.GeoSeries(), token="points_from_xy"
+        func, x, y, z, meta=geopandas.GeoSeries(crs=crs), token="points_from_xy"
     )
 
 

--- a/dask_geopandas/expr.py
+++ b/dask_geopandas/expr.py
@@ -910,7 +910,7 @@ def points_from_xy(df, x="x", y="y", z="z", crs=None):
         )
 
     return df.map_partitions(
-        func, x, y, z, meta=geopandas.GeoSeries(), token="points_from_xy"
+        func, x, y, z, meta=geopandas.GeoSeries(crs=crs), token="points_from_xy"
     )
 
 

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -181,6 +181,7 @@ def test_points_from_xy_with_crs():
     )
     assert isinstance(actual, dask_geopandas.GeoSeries)
     assert_geoseries_equal(actual.compute(), expected)
+    assert actual.crs == expected.crs
 
 
 def test_from_wkt():


### PR DESCRIPTION
Simple re-inclusion of the `crs` argument when passing metadata for `GeoSeries` and `GeoDataFrame` from `points_from_xy`.

Added a small assertion to `test_points_from_xy_with_crs` to ensure the CRS is present on the dask object prior to compute. Addresses #315.