### PR TITLE
Include dask[diagnostics] in dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ hilbertcurve
 pygeohash
 pymorton
 pytest
+bokeh
+distributed


### PR DESCRIPTION
When setting up the project for development, tests fail with the current `requirements-dev.txt` due to the dask diagnostics suite missing.

This includes the required diagnostics libraries (`bokeh` and `distributed`) to ensure all tests pass after a default dev environment setup.