### PR TITLE
remove geom_almost_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 Changelog
 =========
 
+Version 0.5.0 (upcoming)
+------------------------
+
+Deprecations and compatibility notes:
+
+- The deprecated `geom_almost_equals` method has been removed. Use `geom_equals_exact` instead.
+
+
 Version 0.4.3 (January, 2025)
-----------------------------------
+-----------------------------
 
 Packaging:
 

--- a/dask_geopandas/expr.py
+++ b/dask_geopandas/expr.py
@@ -1023,7 +1023,6 @@ for name in [
 for name in [
     "contains",
     "geom_equals",
-    "geom_almost_equals",
     "crosses",
     "disjoint",
     "intersects",

--- a/dask_geopandas/tests/test_core.py
+++ b/dask_geopandas/tests/test_core.py
@@ -282,7 +282,6 @@ def test_project(geoseries_lines):
     [
         "contains",
         "geom_equals",
-        "geom_almost_equals",
         "crosses",
         "disjoint",
         "intersects",

--- a/doc/source/docs/reference/geoseries.rst
+++ b/doc/source/docs/reference/geoseries.rst
@@ -53,7 +53,6 @@ Binary Predicates
    GeoSeries.crosses
    GeoSeries.disjoint
    GeoSeries.geom_equals
-   GeoSeries.geom_almost_equals
    GeoSeries.geom_equals_exact
    GeoSeries.intersects
    GeoSeries.overlaps


### PR DESCRIPTION
fixes dev CI and downstream dev CI by following geopandas in removal of `geom_almost_equals`.