### PR TITLE
ENH: forward lsuffix and rsuffix in dask_geopandas.sjoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Development version
+---------------------
+
+Enhancements:
+
+- Forward `lsuffix` and `rsuffix` in `dask_geopandas.sjoin` and `GeoDataFrame.sjoin` for parity with GeoPandas.
+
 Version 0.5.0 (June 2, 2025)
 ----------------------------
 

--- a/dask_geopandas/expr.py
+++ b/dask_geopandas/expr.py
@@ -742,7 +742,9 @@ class GeoDataFrame(_Frame, dd.DataFrame):
         )
         return aggregated.set_crs(self.crs)
 
-    def sjoin(self, df, how="inner", predicate="intersects"):
+    def sjoin(
+        self, df, how="inner", predicate="intersects", lsuffix="left", rsuffix="right"
+    ):
         """
         Spatial join of two GeoDataFrames.
 
@@ -759,6 +761,12 @@ class GeoDataFrame(_Frame, dd.DataFrame):
             GeoDataFrame. Possible values: 'contains', 'contains_properly',
             'covered_by', 'covers', 'crosses', 'intersects', 'overlaps',
             'touches', 'within'.
+        lsuffix : string, default 'left'
+            Suffix to apply to overlapping column names (excluding geometry) from
+            the left frame.
+        rsuffix : string, default 'right'
+            Suffix to apply to overlapping column names (excluding geometry) from
+            the right frame.
 
         Returns
         -------
@@ -773,7 +781,9 @@ class GeoDataFrame(_Frame, dd.DataFrame):
         all combinations (cartesian/cross product) of all input partition
         of the left and right GeoDataFrame.
         """
-        return dask_geopandas.sjoin(self, df, how=how, predicate=predicate)
+        return dask_geopandas.sjoin(
+            self, df, how=how, predicate=predicate, lsuffix=lsuffix, rsuffix=rsuffix
+        )
 
     def spatial_shuffle(
         self,

--- a/dask_geopandas/sjoin.py
+++ b/dask_geopandas/sjoin.py
@@ -11,7 +11,26 @@ import geopandas
 from .expr import from_geopandas
 
 
-def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
+def _sjoin_partition(left_df, right_df, how, predicate, lsuffix, rsuffix):
+    return geopandas.sjoin(
+        left_df,
+        right_df,
+        how=how,
+        predicate=predicate,
+        lsuffix=lsuffix,
+        rsuffix=rsuffix,
+    )
+
+
+def sjoin(
+    left,
+    right,
+    how="inner",
+    predicate="intersects",
+    lsuffix="left",
+    rsuffix="right",
+    **kwargs,
+):
     """
     Spatial join of two GeoDataFrames.
 
@@ -28,6 +47,12 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
         GeoDataFrame. Possible values: 'contains', 'contains_properly',
         'covered_by', 'covers', 'crosses', 'intersects', 'overlaps',
         'touches', 'within'.
+    lsuffix : string, default 'left'
+        Suffix to apply to overlapping column names (excluding geometry) from
+        ``left``.
+    rsuffix : string, default 'right'
+        Suffix to apply to overlapping column names (excluding geometry) from
+        ``right``.
 
     Returns
     -------
@@ -65,8 +90,15 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
     left = left.optimize()
     right = right.optimize()
 
-    name = "sjoin-" + tokenize(left, right, how, predicate)
-    meta = geopandas.sjoin(left._meta, right._meta, how=how, predicate=predicate)
+    name = "sjoin-" + tokenize(left, right, how, predicate, lsuffix, rsuffix)
+    meta = geopandas.sjoin(
+        left._meta,
+        right._meta,
+        how=how,
+        predicate=predicate,
+        lsuffix=lsuffix,
+        rsuffix=rsuffix,
+    )
 
     if left.spatial_partitions is not None and right.spatial_partitions is not None:
         # Spatial partitions are known -> use them to trim down the list of
@@ -93,11 +125,13 @@ def sjoin(left, right, how="inner", predicate="intersects", **kwargs):
     new_spatial_partitions = []
     for i, (part_left, part_right) in enumerate(zip(parts_left, parts_right)):
         dsk[(name, i)] = (
-            geopandas.sjoin,
+            _sjoin_partition,
             (left._name, part_left),
             (right._name, part_right),
             how,
             predicate,
+            lsuffix,
+            rsuffix,
         )
         # TODO preserve spatial partitions of the output if only left has spatial
         # partitions

--- a/dask_geopandas/tests/test_sjoin.py
+++ b/dask_geopandas/tests/test_sjoin.py
@@ -49,6 +49,57 @@ def test_sjoin_dask_geopandas(naturalearth_lowres, naturalearth_cities):
         dask_geopandas.sjoin(df_points, ddf_polygons, op="within", how="inner")
 
 
+def test_sjoin_lsuffix_rsuffix():
+    left_gdf = geopandas.GeoDataFrame(
+        {"dup_col": [1], "geometry": [shapely.geometry.box(0, 0, 1, 1)]},
+    )
+    right_gdf = geopandas.GeoDataFrame(
+        {"dup_col": [2], "geometry": [shapely.geometry.box(0.5, 0.5, 1.5, 1.5)]},
+    )
+    lsuffix, rsuffix = "_L", "_R"
+    expected = geopandas.sjoin(
+        left_gdf,
+        right_gdf,
+        how="inner",
+        predicate="intersects",
+        lsuffix=lsuffix,
+        rsuffix=rsuffix,
+    ).sort_index()
+
+    ddf_left = dask_geopandas.from_geopandas(left_gdf, npartitions=2)
+    ddf_right = dask_geopandas.from_geopandas(right_gdf, npartitions=2)
+
+    kw = dict(
+        how="inner",
+        predicate="intersects",
+        lsuffix=lsuffix,
+        rsuffix=rsuffix,
+    )
+
+    # dask / geopandas
+    result = dask_geopandas.sjoin(ddf_left, right_gdf, **kw)
+    got = result.compute().sort_index()
+    assert list(got.columns) == list(expected.columns)
+    assert_geodataframe_equal(expected, got)
+
+    # geopandas / dask
+    result = dask_geopandas.sjoin(left_gdf, ddf_right, **kw)
+    got = result.compute().sort_index()
+    assert list(got.columns) == list(expected.columns)
+    assert_geodataframe_equal(expected, got)
+
+    # dask / dask
+    result = dask_geopandas.sjoin(ddf_left, ddf_right, **kw)
+    got = result.compute().sort_index()
+    assert list(got.columns) == list(expected.columns)
+    assert_geodataframe_equal(expected, got)
+
+    assert_geodataframe_equal(
+        expected,
+        ddf_left.sjoin(ddf_right, **kw).compute().sort_index(),
+    )
+
+
 def test_no_value_error():
     # https://github.com/geopandas/dask-geopandas/issues/303
     shape = shapely.geometry.box(-74.5, -74.0, 4.5, 5.0)


### PR DESCRIPTION
## Summary
Expose GeoPandas-compatible `lsuffix` and `rsuffix` on `dask_geopandas.sjoin` and `GeoDataFrame.sjoin`, forwarding them into `_meta` construction and every partition-level `geopandas.sjoin` call.

The `_meta` construction uses the same suffix arguments to ensure schema consistency with computed results. Suffixes are included in `tokenize` to ensure distinct task graphs for different suffix configurations.

## Behavior
- Defaults remain `lsuffix="left"` and `rsuffix="right"` (GeoPandas-aligned).
- This change does not modify join semantics, partition planning, or performance characteristics.
- Partition pairing, pruning (`spatial_partitions` planning join), supported predicates, and `how="inner"` only are unchanged.

## Testing
- New test with overlapping non-geometry columns and custom suffixes.
- Compares against `geopandas.sjoin` for:
  - dask/geopandas
  - geopandas/dask
  - dask/dask
- Verifies `GeoDataFrame.sjoin` behavior matches GeoPandas.